### PR TITLE
Reinstall option does not work for HomebrewInstaller

### DIFF
--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -130,7 +130,11 @@ class HomebrewInstaller(PackageManagerInstaller):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)
         # interactive switch doesn't matter
         if reinstall:
-            return [['brew', 'install', '--force', p] for p in packages]
+            commands = []
+            for p in packages:
+                commands.append(['brew', 'uninstall', '--force', p])
+                commands.append(['brew', 'install', p])
+            return commands
         else:
             return [['brew', 'install', p] for p in packages]
 


### PR DESCRIPTION
Fixing the reinstall option for Homebrew.  In order to properly "reinstall" with homebrew you must execute the uninstall and install commands separately.  The '--force' flag for the install verb does not cause a reinstall.
