### PR TITLE
Fix for handling homebrew tap names.

### DIFF
--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -112,9 +112,12 @@ def brew_detect(formulas, exec_fn=None):
     ret_list = []
     std_out = exec_fn(['brew', 'list'])
     # preserve order
+    clean_formulas = []
+    for f in formulas:
+        clean_formulas.append(f.split('/')[-1])
     for f in std_out.split():
-        if f in formulas:
-            ret_list.append(f)
+        if f in clean_formulas:
+            ret_list.append(formulas[clean_formulas.index(f)])
     return ret_list
 
 class HomebrewInstaller(PackageManagerInstaller):


### PR DESCRIPTION
Fix for handling homebrew tap names.  In the rosdep entries the names must be`ros/fuerte/<formula_name>`, but once installed they show up as `<formula_name>` in the output of `brew list`.  This pull fixes that problem in the brew_detect function.
