### PR TITLE
platforms/gentoo: form a single emerge command

### DIFF
--- a/src/rosdep2/platforms/gentoo.py
+++ b/src/rosdep2/platforms/gentoo.py
@@ -112,11 +112,15 @@ class PortageInstaller(PackageManagerInstaller):
     def get_install_command(self, resolved, interactive=True, reinstall=False):
         atoms = self.get_packages_to_install(resolved, reinstall=reinstall)      
 
+        cmd = [ 'sudo', 'emerge' ]
         if not atoms:
             return []
-        elif interactive:
-            return [['sudo', 'emerge', '-a', atom] for atom in atoms]
-        else:
-            return [['sudo', 'emerge', atom] for atom in atoms]
+
+        if interactive:
+            cmd.append('-a')
+
+        cmd.extend(atoms)
+
+        return [cmd]
 
 


### PR DESCRIPTION
This makes interactive mode (need to type 'yes' to continue) much less painful, and allows portage to neglect items which are pulled in by other items.

An example for the second point: pkgA depends on pkgB.
rosdep wants to install both pkgA and pkgB.
In the old methodology, pkgB could be built a second time, unecissarilly.

Note that this is not the only solution to the "merge twice" annoyance. We could pass '-uN' to emerge to tell it not to merge already merged packages that lack updages or new use flags.
