### PR TITLE
PIP needs to be added to Fedora rosdep

### DIFF
--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -32,6 +32,7 @@ import subprocess
 
 from rospkg.os_detect import OS_RHEL, OS_FEDORA
 
+from .pip import PIP_INSTALLER
 from .source import SOURCE_INSTALLER
 from ..installers import PackageManagerInstaller
 from ..shell_utils import read_stdout
@@ -47,11 +48,13 @@ def register_platforms(context):
     register_rhel(context)
     
 def register_fedora(context):
+    context.add_os_installer_key(OS_FEDORA, PIP_INSTALLER)
     context.add_os_installer_key(OS_FEDORA, YUM_INSTALLER)
     context.add_os_installer_key(OS_FEDORA, SOURCE_INSTALLER)
     context.set_default_os_installer_key(OS_FEDORA, YUM_INSTALLER)
 
 def register_rhel(context):
+    context.add_os_installer_key(OS_RHEL, PIP_INSTALLER)
     context.add_os_installer_key(OS_RHEL, YUM_INSTALLER)
     context.add_os_installer_key(OS_RHEL, SOURCE_INSTALLER)
     context.set_default_os_installer_key(OS_RHEL, YUM_INSTALLER)


### PR DESCRIPTION
We were doing a source install on Fedora, and found that even if PIP was listed in one of the rosdep sources (python.yaml, etc), it was not seen as a valid installation source and thus was ignored.
