### PR TITLE
Install all YUM packages in one command

### DIFF
--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -92,7 +92,7 @@ class YumInstaller(PackageManagerInstaller):
         if not packages:
             return []
         elif not interactive:
-            return [['sudo', 'yum', '-y', 'install'] + packages]
+            return [['sudo', 'yum', '-y', '--skip-broken', 'install'] + packages]
         else:
-            return [['sudo', 'yum', 'install'] + packages]
+            return [['sudo', 'yum', '--skip-broken', 'install'] + packages]
 


### PR DESCRIPTION
This will make one call to YUM instead of one for each package. This is a significant speed boost and seems to work much better. Adding the --skip-broken flag makes YUM act a lot like it did before, skipping packages that it cannot install (for whatever reason) and installing the ones it can.

If there is a reason that this wasn't implemented before, I'm not aware of it.
