### PR TITLE
Return None if pkg-config gives a non-zero exit code

### DIFF
--- a/src/rosdep2/rospack.py
+++ b/src/rosdep2/rospack.py
@@ -42,8 +42,11 @@ from .sources_list import get_sources_cache_dir
 
 
 def call_pkg_config(option, pkg_name):
-    value = subprocess.check_output(['pkg-config', option, pkg_name])
-    return value.strip()
+    try:
+        value = subprocess.check_output(['pkg-config', option, pkg_name])
+        return value.strip()
+    except CalledProcessError:
+        return None
 
 
 def init_rospack_interface():


### PR DESCRIPTION
This prevents the ugly stack trace that comes with
missing dependencies and makes the build log harder
to read.

Note that a failure to execute pkg-config at all
raises an OSError exception, which is not caught as it
indicates an actual bug or severe misconfiguration.

This is part of a proposed fix for ros/rosdep#34
