### PR TITLE
Catch correct exception

### DIFF
--- a/src/rosdep2/rospack.py
+++ b/src/rosdep2/rospack.py
@@ -45,7 +45,7 @@ def call_pkg_config(option, pkg_name):
     try:
         value = subprocess.check_output(['pkg-config', option, pkg_name])
         return value.strip()
-    except CalledProcessError:
+    except subprocess.CalledProcessError:
         return None
 
 


### PR DESCRIPTION
The CalledProcessError exception belongs to the
subprocess module.

My previous pull request was faulty. Sorry for that. Now it works as expected.
