### PR TITLE
rosdep-source not included in python-rosdep ubuntu package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     setup_requires=['nose >= 1.0'],
     test_suite='nose.collector',
     test_requires=['mock'],
-    scripts=['scripts/rosdep'],
+    scripts=['scripts/rosdep', 'scripts/rosdep-source'],
     author="Tully Foote, Ken Conley",
     author_email="foote@willowgarage.com, kwc@willowgarage.com",
     url="http://www.ros.org/wiki/rosdep",


### PR DESCRIPTION
I have a stock install of the python-rosdep debian package on Ubuntu 12.04 Precise (version 0.10.12-1).  The package does not include the rosdep-source script, so source installs always fail, as shown below.  Installs work correctly if I manually download rosdep-source (e.g. from https://raw.github.com/ros/rosdep/master/scripts/rosdep-source) and place it on my path.

```
$ rosdep install mypackage
Executing script below with cwd=/tmp
{{{
#!/bin/bash
dpkg-query --show --showformat='${Status}' myrosdep | grep --quiet ' installed$'
exit "$?"
}}}

Executing script below with cwd=/tmp
{{{
#!/bin/bash
dpkg-query --show --showformat='${Status}' myrosdep | grep --quiet ' installed$'
exit "$?"
}}}

executing command [rosdep-source install http://my.host/path.to.rdmanifest]

ERROR: Rosdep experienced an internal error: [Errno 2] No such file or directory
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/rosdep2/main.py", line 116, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/usr/lib/pymodules/python2.7/rosdep2/main.py", line 257, in _rosdep_main
    return _package_args_handler(command, parser, options, args)
  File "/usr/lib/pymodules/python2.7/rosdep2/main.py", line 341, in _package_args_handler
    return command_handlers[command](lookup, packages, options)
  File "/usr/lib/pymodules/python2.7/rosdep2/main.py", line 500, in command_install
    installer.install(uninstalled, **install_options)
  File "/usr/lib/pymodules/python2.7/rosdep2/installers.py", line 477, in install
    verbose=verbose)
  File "/usr/lib/pymodules/python2.7/rosdep2/installers.py", line 526, in install_resolved
    result = subprocess.call(sub_command)
  File "/usr/lib/python2.7/subprocess.py", line 493, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1249, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

Here's info on the package:

```
$ dpkg --status python-rosdep
Package: python-rosdep
Status: install ok installed
Priority: optional
Section: python
Installed-Size: 328
Maintainer: Tully Foote, Ken Conley <foote@willowgarage.com, kwc@willowgarage.com>
Architecture: all
Source: rosdep
Version: 0.10.12-1
Provides: python2.6-rosdep
Depends: python (>= 2.6), python-support (>= 0.90.0), python-rospkg, python-yaml (>= 3.1), python-catkin-pkg
Description: rosdep package manager abstrction tool for ROS
 Command-line tool for installing system dependencies on a variety of platforms.
Python-Version: 2.6

$ dpkg --listfiles python-rosdep
/.
/usr
/usr/bin
/usr/bin/rosdep
/usr/share
/usr/share/python-support
/usr/share/python-support/python-rosdep.public
/usr/share/pyshared
/usr/share/pyshared/rosdep-0.10.12.egg-info
/usr/share/pyshared/rosdep-0.10.12.egg-info/SOURCES.txt
/usr/share/pyshared/rosdep-0.10.12.egg-info/PKG-INFO
/usr/share/pyshared/rosdep-0.10.12.egg-info/requires.txt
/usr/share/pyshared/rosdep-0.10.12.egg-info/dependency_links.txt
/usr/share/pyshared/rosdep-0.10.12.egg-info/top_level.txt
/usr/share/pyshared/rosdep2
/usr/share/pyshared/rosdep2/installers.py
/usr/share/pyshared/rosdep2/dependency_graph.py
/usr/share/pyshared/rosdep2/rospkg_loader.py
/usr/share/pyshared/rosdep2/rospack.py
/usr/share/pyshared/rosdep2/model.py
/usr/share/pyshared/rosdep2/core.py
/usr/share/pyshared/rosdep2/shell_utils.py
/usr/share/pyshared/rosdep2/rep3.py
/usr/share/pyshared/rosdep2/main.py
/usr/share/pyshared/rosdep2/lookup.py
/usr/share/pyshared/rosdep2/platforms
/usr/share/pyshared/rosdep2/platforms/osx.py
/usr/share/pyshared/rosdep2/platforms/gentoo.py
/usr/share/pyshared/rosdep2/platforms/arch.py
/usr/share/pyshared/rosdep2/platforms/cygwin.py
/usr/share/pyshared/rosdep2/platforms/redhat.py
/usr/share/pyshared/rosdep2/platforms/debian.py
/usr/share/pyshared/rosdep2/platforms/gem.py
/usr/share/pyshared/rosdep2/platforms/opensuse.py
/usr/share/pyshared/rosdep2/platforms/pip.py
/usr/share/pyshared/rosdep2/platforms/freebsd.py
/usr/share/pyshared/rosdep2/platforms/source.py
/usr/share/pyshared/rosdep2/gbpdistro_support.py
/usr/share/pyshared/rosdep2/catkin_packages.py
/usr/share/pyshared/rosdep2/catkin_support.py
/usr/share/pyshared/rosdep2/loader.py
/usr/share/pyshared/rosdep2/__init__.py
/usr/share/pyshared/rosdep2/sources_list.py
/usr/share/doc
/usr/share/doc/python-rosdep
/usr/share/doc/python-rosdep/changelog.Debian.gz
```
