### PR TITLE
Cannot resolve ubuntu targets for Fuerte

### DIFF
--- a/src/rosdep2/catkin_support.py
+++ b/src/rosdep2/catkin_support.py
@@ -22,14 +22,15 @@ import os
 from subprocess import Popen, PIPE, CalledProcessError
 
 from . import create_default_installer_context
+from .lookup import RosdepLookup
 from .platforms.debian import APT_INSTALLER
 from .platforms.osx import BREW_INSTALLER
 from .platforms.pip import PIP_INSTALLER
 from .platforms.redhat import YUM_INSTALLER
-from .sources_list import get_sources_list_dir, DataSourceMatcher, SourcesListLoader
-from .lookup import RosdepLookup
-from .rospkg_loader import DEFAULT_VIEW_KEY
+from .rep3 import download_targets_data
 from .rosdistrohelper import get_targets
+from .rospkg_loader import DEFAULT_VIEW_KEY
+from .sources_list import get_sources_list_dir, DataSourceMatcher, SourcesListLoader
 
 class ValidationFailed(Exception):
     pass
@@ -56,6 +57,11 @@ def get_ubuntu_targets(rosdistro):
     :raises: :exc:`ValidationFailed`
     """
     targets_data = get_targets()
+    legacy_targets = download_targets_data()
+    if 'fuerte' in legacy_targets:
+        targets_data['fuerte'] = {'ubuntu': legacy_targets['fuerte']}
+    if 'electric' in legacy_targets:
+        targets_data['electric'] = {'ubuntu': legacy_targets['electric']}
     return targets_data[rosdistro]['ubuntu']
 
 def get_installer(installer_name):
@@ -69,7 +75,7 @@ default_installers = {
     'osx': [BREW_INSTALLER, PIP_INSTALLER],
     'ubuntu': [APT_INSTALLER],
     'fedora': [YUM_INSTALLER],
-    }
+}
 
 
 def resolve_for_os(rosdep_key, view, installer, os_name, os_version):

--- a/src/rosdep2/rosdistrohelper.py
+++ b/src/rosdep2/rosdistrohelper.py
@@ -28,15 +28,17 @@
 # Author Paul Mathieu/paul@osrfoundation.org
 
 import rosdistro
-import warnings
+
 
 class PreRep137Warning(UserWarning):
     pass
 
-class  _RDCache:
+
+class _RDCache:
     index_url = None
     index = None
     release_files = {}
+
 
 def _check_cache():
     if _RDCache.index_url != rosdistro.get_index_url():
@@ -51,11 +53,13 @@ def get_index():
         _RDCache.index = rosdistro.get_index(_RDCache.index_url)
     return _RDCache.index
 
+
 def get_release_file(distro):
     _check_cache()
     if distro not in _RDCache.release_files:
         _RDCache.release_files[distro] = rosdistro.get_release_file(get_index(), distro)
     return _RDCache.release_files[distro]
+
 
 def get_targets():
     return dict((d, get_release_file(d).platforms) for d in get_index().distributions)


### PR DESCRIPTION
Bloom uses rosdep to get a list of the default ubuntu targets, but now for Fuerte it fails with:

```
% ipython
Python 2.7.2 (default, Oct 11 2012, 20:14:37)
Type "copyright", "credits" or "license" for more information.

IPython 0.13.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from rosdep2 import catkin_support

In [2]: catkin_support.get_ubuntu_targets('fuerte')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-2-cabff3dfebd8> in <module>()
----> 1 catkin_support.get_ubuntu_targets('fuerte')

/Library/Python/2.7/site-packages/rosdep2/catkin_support.pyc in get_ubuntu_targets(rosdistro)
     57     """
     58     targets_data = get_targets()
---> 59     return targets_data[rosdistro]
     60
     61 def get_installer(installer_name):

KeyError: 'fuerte'

In [3]: catkin_support.get_ubuntu_targets('groovy')
Out[3]: ['oneiric', 'precise', 'quantal']
```

This is likely a regression from the new rosdistro stuff.
