### PR TITLE
Address Issue #234; handle duplicate dependencies

### DIFF
--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -29,6 +29,7 @@
 # Author Tully Foote/tfoote@willowgarage.com, Ken Conley
 
 import subprocess
+import re
 
 from rospkg.os_detect import OS_OSX
 
@@ -131,6 +132,7 @@ class HomebrewInstaller(PackageManagerInstaller):
         if not is_brew_installed():
             raise InstallFailed((BREW_INSTALLER, 'Homebrew is not installed'))
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)
+        packages = self.remove_duplicate_dependencies(packages)
         # interactive switch doesn't matter
         if reinstall:
             commands = []
@@ -141,3 +143,23 @@ class HomebrewInstaller(PackageManagerInstaller):
         else:
             return [['brew', 'install', p] for p in packages]
 
+    def remove_duplicate_dependencies(self, packages):
+        if not is_brew_installed():
+            raise InstallFailed((BREW_INSTALLER, 'Homebrew is not installed'))
+
+        # we'll remove dependencies from this copy and return it
+        packages_copy = list(packages)
+
+        # find all dependencies for each package
+        for p in packages:
+            sub_command = ['brew', 'info', p]
+            output = subprocess.Popen(sub_command, stdout=subprocess.PIPE).communicate()[0]
+            match = re.findall("Depends on: (.*)", output)
+            if match:
+                dependencies = re.split(',', match[0])
+                for d in dependencies:
+                    d = d.strip()
+                    # remove duplicate dependency from package list
+                    if d in packages:
+                        packages_copy.remove(d)
+        return packages_copy

--- a/test/test_rosdep_osx.py
+++ b/test/test_rosdep_osx.py
@@ -71,14 +71,17 @@ def test_HomebrewInstaller():
 
     @patch('rosdep2.platforms.osx.is_brew_installed')
     @patch.object(HomebrewInstaller, 'get_packages_to_install')
-    def test(mock_method, mock_brew_installed):
+    @patch.object(HomebrewInstaller, 'remove_duplicate_dependencies')
+    def test(mock_get_packages_to_install, mock_remove_duplicate_dependencies, mock_brew_installed):
         mock_brew_installed.return_value = True
         
         installer = HomebrewInstaller()
-        mock_method.return_value = []
+        mock_get_packages_to_install.return_value = []
+        mock_remove_duplicate_dependencies = mock_get_packages_to_install
         assert [] == installer.get_install_command(['fake'])
 
-        mock_method.return_value = ['subversion', 'bazaar']
+        mock_get_packages_to_install.return_value = ['subversion', 'bazaar']
+        mock_remove_duplicate_dependencies = mock_get_packages_to_install
         expected = [['brew', 'install', 'subversion'],
                     ['brew', 'install', 'bazaar']]
         # brew is always non-interactive


### PR DESCRIPTION
In some instances brew installs packages that have dependencies already
listed as a 'resolved' dependency.  This patch checks the brew info for
each package and builds a list of dependencies-of-dependencies.  If any
of these dependencies-of-dependencies is already slated for
installation, it is removed from the list of resolved packages.

-Deal with empty match for regular expression

-Use Popen to maintain compatibility w/python 2.6

-Disable the HomebrewInstaller test if brew is not installed
