### PR TITLE
Added ArchLinux AUR support (uses packer or yaourt).

### DIFF
--- a/src/rosdep2/platforms/arch.py
+++ b/src/rosdep2/platforms/arch.py
@@ -61,7 +61,7 @@ def find_providers(term):
     we need to search on our own (or use a nonstandard library)."""
     providers = []
 
-    provision_re = re.compile("\n%PROVIDES%(\n.+)*(\n" + term + "\n)")
+    provision_re = re.compile("\n%PROVIDES%(\n.+)*(\n" + re.escape(term) + "\n)")
 
     for pkgspec in os.listdir('/var/lib/pacman/local'):
         desc_path = os.path.join('/var/lib/pacman/local', pkgspec, 'desc')


### PR DESCRIPTION
I've added 'aur' as a separate installer type, to be used as follows:

``` yaml
dep_name:
  arch:
    aur: [my_aur_pkg]
```

When rosdep is initialized, it searches for yaourt and packer in your
path, and if either one is found, rosdep will register the AUR installer
with the discovered script (using packer if both are found).

I considered the following alternative arrangements:

``` yaml
dep_name:
  arch: [aur/aur_pkg, official_pkg, community/aur_pkg2]
  # Here, 'aur/'-prefixed packages go to packer, otherwise pacman.

dep_name:
  arch:
    packer: [aur_pkg]
```

The major advantage of alternative #1 is that it allows you to
specify both AUR and official packages to satisfy a single dependency
key. Per REP 111, "rosdep rules are only allowed to specify a single
package manager to fulfill them." So far this only affects the 'eclipse'
rule, which required the 'eclipse' package and three AUR packages.
