### PR TITLE
Remove unnecessary str conversion

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -486,7 +486,7 @@ def command_check(lookup, packages, options):
             if isinstance(ex, rospkg.ResourceNotFound):
                 print("ERROR[%s]: resource not found [%s]"%(package_name, ex.args[0]), file=sys.stderr)
             else:
-                print("ERROR[%s]: %s"%(package_name, str(ex)), file=sys.stderr)                
+                print("ERROR[%s]: %s"%(package_name, ex), file=sys.stderr)                
     if uninstalled:
         return 1
     else:


### PR DESCRIPTION
Using str(obj) will fail if the object is a unicode string and contains extended characters. However, since the argument to the % operator is certainly a tuple, there is no question as to the fact that the passed object is to be converted to a string (ascii OR unicode). This means that the str() is not necessary to perform the conversion in this case.

To clarify:

This will NOT always work, such as when notastring is a tuple containing multiple objects:
print("%s" % notastring)

These will work:
print("%s" % (notastring,))
print("%s %s" % (notastring, somethingelse))

This is likely not the only place where str() will need to be removed because of the possibility of an extended character.

This was discovered when F19 used extended characters in the release name. Anywhere a string containing the os_version is passed to str(), this problem will present itself.

This is related to https://github.com/ros-infrastructure/rospkg/pull/54
