### PR TITLE
Implement --as-root option.

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -320,6 +320,17 @@ class PackageManagerInstaller(Installer):
         """
         self.detect_fn = detect_fn
         self.supports_depends = supports_depends
+        self.as_root = True
+        self.sudo_command = 'sudo'
+
+    def elevate_priv(self, cmd):
+        """
+        Prepend *self.sudo_command* to the command if *self.as_root* is ``True``.
+
+        :param list cmd: list of strings comprising the command
+        :returns: a list of commands
+        """
+        return (self.sudo_command.split() if self.as_root else []) + cmd
 
     def resolve(self, rosdep_args):
         """

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -206,6 +206,31 @@ ERROR: your rosdep installation has not been initialized yet.  Please run:
         sys.exit(1)
     else:
         return True
+
+
+def key_list_to_dict(key_list):
+    """
+    Convert a list of strings of the form 'foo:bar' to a dictionary.
+
+    Splits strings of the form 'foo:bar quux:quax' into separate entries.
+    """
+    try:
+        key_list = [key for s in key_list for key in s.split(' ')]
+        return dict(map(lambda s: [t.strip() for t in s.split(':')], key_list))
+    except ValueError as e:
+        raise UsageError("Invalid 'key:value' list: '%s'" % ' '.join(key_list))
+
+
+def str_to_bool(s):
+    """Maps a string to bool. Supports true/false, and yes/no, and is case-insensitive"""
+    s = s.lower()
+    if s in ['yes', 'true']:
+        return True
+    elif s in ['no', 'false']:
+        return False
+    else:
+        raise UsageError("Cannot parse '%s' as boolean" % s)
+
     
 def _rosdep_main(args):
     # sources cache dir is our local database.  
@@ -259,6 +284,11 @@ def _rosdep_main(args):
                       help="Explicitly sets the ROS distro to use, overriding "
                            "the normal method of detecting the ROS distro "
                            "using the ROS_DISTRO environment variable.")
+    parser.add_option("--as-root", default=[], action='append',
+                      metavar="INSTALLER_KEY:<bool>", help="Override "
+                      "whether sudo is used for a specific installer, "
+                      "e.g. '--as-root pip:false' or '--as-root \"pip:no homebrew:yes\"'. "
+                      "Can be specified multiple times.")
 
     options, args = parser.parse_args(args)
     if options.print_version:
@@ -277,6 +307,9 @@ def _rosdep_main(args):
 
     if options.ros_distro:
         os.environ['ROS_DISTRO'] = options.ros_distro
+
+    # Convert list of keys to dictionary
+    options.as_root = dict((k, str_to_bool(v)) for k, v in key_list_to_dict(options.as_root).items())
 
     if not command in ['init', 'update']:
         check_for_sources_list_init(options.sources_cache_dir)
@@ -394,15 +427,23 @@ def convert_os_override_option(options_os_override):
     os_version = val[val.find(':')+1:]
     return os_name, os_version
     
-def configure_installer_context_os(installer_context, options):
+def configure_installer_context(installer_context, options):
     """
-    Override the OS detector in *installer_context* if necessary.
+    Configure the *installer_context* from *options*.
+
+    - Override the OS detector in *installer_context* if necessary.
+    - Set *as_root* for installers if specified.
 
     :raises: :exc:`UsageError` If user input options incorrectly
     """
     os_override = convert_os_override_option(options.os_override)
     if os_override is not None:
         installer_context.set_os_override(*os_override)
+    for k,v in options.as_root.items():
+        try:
+            installer_context.get_installer(k).as_root = v
+        except KeyError:
+            raise UsageError("Installer '%s' not defined." % k)
     
 def command_init(options):
     try:
@@ -498,7 +539,7 @@ def command_check(lookup, packages, options):
     verbose = options.verbose
     
     installer_context = create_default_installer_context(verbose=verbose)
-    configure_installer_context_os(installer_context, options)
+    configure_installer_context(installer_context, options)
     installer = RosdepInstaller(installer_context, lookup)
 
     uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=verbose)
@@ -539,7 +580,7 @@ def command_install(lookup, packages, options):
 
     # setup installer
     installer_context = create_default_installer_context(verbose=options.verbose)
-    configure_installer_context_os(installer_context, options)
+    configure_installer_context(installer_context, options)
     installer = RosdepInstaller(installer_context, lookup)
 
     if options.reinstall:
@@ -594,7 +635,7 @@ def command_db(options):
     # exact same setup logic as command_resolve, should possibly combine
     lookup = _get_default_RosdepLookup(options)
     installer_context = create_default_installer_context(verbose=options.verbose)
-    configure_installer_context_os(installer_context, options)
+    configure_installer_context(installer_context, options)
     os_name, os_version = installer_context.get_os_name_and_version()
     try:
         installer_keys = installer_context.get_os_installer_keys(os_name)
@@ -660,7 +701,7 @@ def command_where_defined(args, options):
 def command_resolve(args, options):
     lookup = _get_default_RosdepLookup(options)
     installer_context = create_default_installer_context(verbose=options.verbose)
-    configure_installer_context_os(installer_context, options)
+    configure_installer_context(installer_context, options)
 
     installer, installer_keys, default_key, \
             os_name, os_version = get_default_installer(installer_context=installer_context,

--- a/src/rosdep2/platforms/arch.py
+++ b/src/rosdep2/platforms/arch.py
@@ -61,4 +61,4 @@ class PacmanInstaller(PackageManagerInstaller):
         if not packages:
             return []
         else:
-            return [['sudo', 'pacman', '-Sy', '--needed', p] for p in packages]
+            return [self.elevate_priv(['pacman', '-Sy', '--needed', p]) for p in packages]

--- a/src/rosdep2/platforms/cygwin.py
+++ b/src/rosdep2/platforms/cygwin.py
@@ -62,6 +62,8 @@ class AptCygInstaller(PackageManagerInstaller):
 
     def __init__(self):
         super(AptCygInstaller, self).__init__(cygcheck_detect)
+        self.as_root = False
+        self.sudo_command = 'cygstart --action=runas'
 
     def get_install_command(self, resolved, interactive=True, reinstall=False):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)        
@@ -69,7 +71,7 @@ class AptCygInstaller(PackageManagerInstaller):
         if not packages:
             return []
         else:
-            return [['apt-cyg', '-m', 'ftp://sourceware.org/pub/cygwinports', 'install']+packages]
+            return [self.elevate_priv(['apt-cyg', '-m', 'ftp://sourceware.org/pub/cygwinports', 'install'])+packages]
 
 if __name__ == '__main__':
     print("test cygcheck_detect(true)", cygcheck_detect('cygwin'))

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -105,6 +105,6 @@ class AptInstaller(PackageManagerInstaller):
         if not packages:
             return []
         if not interactive:
-            return [['sudo', 'apt-get', 'install', '-y', p] for p in packages]
+            return [self.elevate_priv(['apt-get', 'install', '-y', p]) for p in packages]
         else:
-            return [['sudo', 'apt-get', 'install', p] for p in packages]
+            return [self.elevate_priv(['apt-get', 'install', p]) for p in packages]

--- a/src/rosdep2/platforms/freebsd.py
+++ b/src/rosdep2/platforms/freebsd.py
@@ -84,4 +84,4 @@ class PkgAddInstaller(Installer):
             return []
         else:
             #pkg_add does not have a non-interactive command
-            return [['sudo', '/usr/sbin/pkg_add', '-r']+packages]
+            return [self.elevate_priv(['/usr/sbin/pkg_add', '-r'])+packages]

--- a/src/rosdep2/platforms/gem.py
+++ b/src/rosdep2/platforms/gem.py
@@ -82,5 +82,5 @@ class GemInstaller(PackageManagerInstaller):
         if not packages:
             return []
         else:
-            return [['sudo', 'gem', 'install', p] for p in packages]
+            return [self.elevate_priv(['gem', 'install', p]) for p in packages]
             

--- a/src/rosdep2/platforms/gentoo.py
+++ b/src/rosdep2/platforms/gentoo.py
@@ -110,7 +110,7 @@ class PortageInstaller(PackageManagerInstaller):
     def get_install_command(self, resolved, interactive=True, reinstall=False):
         atoms = self.get_packages_to_install(resolved, reinstall=reinstall)      
 
-        cmd = [ 'sudo', 'emerge' ]
+        cmd = self.elevate_priv(['emerge'])
         if not atoms:
             return []
 

--- a/src/rosdep2/platforms/opensuse.py
+++ b/src/rosdep2/platforms/opensuse.py
@@ -65,6 +65,6 @@ class ZypperInstaller(PackageManagerInstaller):
         if not packages:
             return []
         if not interactive:
-            return [['sudo', 'zypper', 'install', '-yl']+packages]
+            return [self.elevate_priv(['zypper', 'install', '-yl'])+packages]
         else:
-            return [['sudo', 'zypper', 'install']+packages]
+            return [self.elevate_priv(['zypper', 'install'])+packages]

--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -101,7 +101,7 @@ class MacportsInstaller(PackageManagerInstaller):
             return []
         else:
             #TODO: interactive
-            return [['sudo', 'port', 'install', p] for p in packages]
+            return [self.elevate_priv(['port', 'install', p]) for p in packages]
 
 def is_brew_installed():
     try:
@@ -249,6 +249,7 @@ class HomebrewInstaller(PackageManagerInstaller):
 
     def __init__(self):
         super(HomebrewInstaller, self).__init__(brew_detect, supports_depends=True)
+        self.as_root = False
 
     def resolve(self, rosdep_args):
         """
@@ -318,11 +319,11 @@ class HomebrewInstaller(PackageManagerInstaller):
             commands = []
             for r in resolved:
                 # --force uninstalls all versions of that package
-                commands.append(['brew', 'uninstall', '--force', r.package])
-                commands.append(['brew', 'install'] + r.to_list())
+                commands.append(self.elevate_priv(['brew', 'uninstall', '--force', r.package]))
+                commands.append(self.elevate_priv(['brew', 'install'] + r.to_list()))
             return commands
         else:
-            return [['brew', 'install'] + r.to_list() for r in resolved]
+            return [self.elevate_priv(['brew', 'install'] + r.to_list()) for r in resolved]
 
     def remove_duplicate_dependencies(self, resolved):
         # TODO: we do not look at options here, however the install check later

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -81,5 +81,5 @@ class PipInstaller(PackageManagerInstaller):
         if not packages:
             return []
         else:
-            return [['sudo', 'pip', 'install', '-U', p] for p in packages]
+            return [self.elevate_priv(['pip', 'install', '-U', p]) for p in packages]
             

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -92,7 +92,7 @@ class YumInstaller(PackageManagerInstaller):
         if not packages:
             return []
         elif not interactive:
-            return [['sudo', 'yum', '-y', '--skip-broken', 'install'] + packages]
+            return [self.elevate_priv(['yum', '-y', '--skip-broken', 'install']) + packages]
         else:
-            return [['sudo', 'yum', '--skip-broken', 'install'] + packages]
+            return [self.elevate_priv(['yum', '--skip-broken', 'install']) + packages]
 


### PR DESCRIPTION
- The option allows to overwrite defaults for using sudo with specific
  installers from the command line.
- The only installers currently not using sudo by default are homebrew and cygwin.

---
- This needs some testing, possibly unit tests.
- Should we change the name of the option?
