### PR TITLE
Update test_rosdep_installers.py

### DIFF
--- a/test/test_rosdep_installers.py
+++ b/test/test_rosdep_installers.py
@@ -29,7 +29,10 @@ from __future__ import print_function
 
 import os
 import sys
-import cStringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from rospkg import RosPack, RosStack
 
@@ -68,13 +71,13 @@ def test_InstallerContext_ctor():
     detect = OsDetect()
     context = InstallerContext(detect)
     assert context.get_os_detect() == detect
-    assert [] == context.get_installer_keys()
-    assert [] == context.get_os_keys()
+    assert len(context.get_installer_keys()) == 0
+    assert len(context.get_os_keys()) == 0
 
     context.verbose = True
     assert context.get_os_detect() == detect
-    assert [] == context.get_installer_keys()
-    assert [] == context.get_os_keys()
+    assert len(context.get_installer_keys()) == 0
+    assert len(context.get_os_keys()) == 0
     
 def test_InstallerContext_get_os_version_type():
     from rospkg.os_detect import OS_UBUNTU
@@ -158,17 +161,17 @@ def test_InstallerContext_installers():
     installer2 = FakeInstaller2()
     context.set_installer(key, installer)
     assert context.get_installer(key) == installer
-    assert context.get_installer_keys() == [key]
+    assert list(context.get_installer_keys()) == [key]
 
     # repeat with same args
     context.set_installer(key, installer)
     assert context.get_installer(key) == installer
-    assert context.get_installer_keys() == [key]
+    assert list(context.get_installer_keys()) == [key]
 
     # repeat with new installer
     context.set_installer(key, installer2)
     assert context.get_installer(key) == installer2
-    assert context.get_installer_keys() == [key]
+    assert list(context.get_installer_keys()) == [key]
     
     # repeat with new key
     key2 = 'fake-port'
@@ -327,7 +330,10 @@ def test_PackageManagerInstaller_depends():
     assert ['foo', 'bar'] == installer.get_depends(dict(depends=['foo', 'bar'], packages=['baz']))
     installer = PackageManagerInstaller(detect_fn_all, supports_depends=False)
     assert [] == installer.get_depends(dict(depends=['foo', 'bar'], packages=['baz']))
-
+    """
+    commenting this part as "installer.unique" is not used on rosdep 2
+    """
+    """
 def test_PackageManagerInstaller_unique():
     from rosdep2.installers import PackageManagerInstaller
 
@@ -342,6 +348,7 @@ def test_PackageManagerInstaller_unique():
     assert set(['a', 'b', 'c']) == set(installer.unique(['a'], ['b'], ['c']))
     assert set(['a', 'b', 'c']) == set(installer.unique(['a', 'b'], ['c']))    
     assert set(['a', 'b', 'c']) == set(installer.unique(['a', 'b'], ['c', 'a']))    
+    """
 
 def test_PackageManagerInstaller_is_installed():
     from rosdep2.installers import PackageManagerInstaller
@@ -483,7 +490,7 @@ def test_RosdepInstaller_get_uninstalled_unconfigured():
         # make sure there is an error when we lookup something that resolves to an apt depend
         uninstalled, errors = installer.get_uninstalled(['roscpp_fake'], verbose)
         assert not uninstalled, uninstalled
-        assert errors.keys() == ['roscpp_fake']
+        assert list(errors.keys()) == ['roscpp_fake']
 
         uninstalled, errors = installer.get_uninstalled(['roscpp_fake', 'stack1_p1'], verbose)
         assert not uninstalled, uninstalled
@@ -522,8 +529,8 @@ from contextlib import contextmanager
 def fakeout():
     realstdout = sys.stdout
     realstderr = sys.stderr
-    fakestdout = cStringIO.StringIO()
-    fakestderr = cStringIO.StringIO()
+    fakestdout = StringIO()
+    fakestderr = StringIO()
     sys.stdout = fakestdout
     sys.stderr = fakestderr
     yield fakestdout, fakestderr
@@ -562,7 +569,7 @@ def test_RosdepInstaller_install_resolved():
                 raise
             return True
     stdout_lines = [x.strip() for x in stdout.getvalue().split('\n') if x.strip()]
-    assert stdout_lines == ['#[apt] Installation commands:',
-                            'sudo apt-get install rosdep-fake1',
-                            'sudo apt-get install rosdep-fake2',
-                            ], ("%s: %s"%(stdout.getvalue(), stdout_lines))
+    assert len(stdout_lines) == 3
+    assert stdout_lines[0] == '#[apt] Installation commands:'
+    assert 'sudo apt-get install rosdep-fake1' in stdout_lines, 'stdout_lines: %s' % stdout_lines
+    assert 'sudo apt-get install rosdep-fake2' in stdout_lines, 'stdout_lines: %s' % stdout_lines


### PR DESCRIPTION
removed test cases using installer.unique() as it is not used in rosdep2
