### PR TITLE
Support RPM virtual packages

### DIFF
--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -63,7 +63,7 @@ def register_rhel(context):
 def rpm_detect(packages, exec_fn=None):
     ret_list = []
     #cmd = ['rpm', '-q', '--qf ""']  # suppress output for installed packages
-    cmd = ['rpm', '-q', '--qf', '%{NAME}\n']  # output: "pkg_name" for installed, error text for not installed packages
+    cmd = ['rpm', '-q', '--whatprovides', '--qf', '[%{PROVIDES}\n]']  # output: "pkg_name" for installed, error text for not installed packages
     cmd.extend(packages)
 
     if exec_fn is None:


### PR DESCRIPTION
Virtual packages can be used to add dependencies on specific libraries, make a dependency architecture specific, and much more.

Some RPMs also provide additional capabilities via virtual packages. For instance, `joystick` is no longer an RPM in Fedora, but is instead provided by `linuxconsoletools` as a virtual package. Trying to install
`joystick` will install `linuxconsoletools`, but rosdep will not detect the installation and will assert a failure.

This patch modifies rosdep look for what packages _provide_ a given package name, not just what packages have a matching name.
