### PR TITLE
Workaround for extended characters in errors

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -516,11 +516,11 @@ def command_check(lookup, packages, options):
 
 def error_to_human_readable(error):
     if isinstance(error, rospkg.ResourceNotFound):
-        return "Missing resource %s"%(str(error))
+        return "Missing resource %s"%(error,)
     elif isinstance(error, ResolutionError):
-        return str(error.args[0])
+        return "%s"%(error.args[0],)
     else:
-        return str(error)
+        return "%s"%(error,)
     
 def command_install(lookup, packages, options):
     # map options


### PR DESCRIPTION
Same kind of error as https://github.com/ros-infrastructure/rosdep/commit/a088598a1e8937cec317eccfb449e354e33da580

Described in https://github.com/ros-infrastructure/rospkg/pull/54

Is there a better way to do this? The problem is that `str()` converts to ascii explicitly...
