### PR TITLE
Updates to RPM and DNF Package Manager

### DIFF
--- a/test/test_rosdep_redhat.py
+++ b/test/test_rosdep_redhat.py
@@ -47,6 +47,35 @@ def test_rpm_detect():
     val = rpm_detect(['tinyxml-dev'], exec_fn=m)
     assert val == [], val
 
+def test_DnfInstaller():
+    from rosdep2.platforms.redhat import DnfInstaller
+
+    @patch.object(DnfInstaller, 'get_packages_to_install')
+    def test(mock_method):
+        installer = DnfInstaller()
+        mock_method.return_value = []
+        assert [] == installer.get_install_command(['fake'])
+
+        # no interactive option with YUM
+        mock_method.return_value = ['a', 'b']
+        expected = [['sudo', 'dnf', '--assumeyes', '--quiet', 'install', 'a', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=False, quiet=True)
+        assert val == expected, val + expected
+        expected = [['sudo', 'dnf', '--quiet', 'install', 'a', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=True, quiet=True)
+        assert val == expected, val + expected
+        expected = [['sudo', 'dnf', '--assumeyes', 'install', 'a', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=False, quiet=False)
+        assert val == expected, val + expected
+        expected = [['sudo', 'dnf', 'install', 'a', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=True, quiet=False)
+        assert val == expected, val + expected
+    try:
+        test()
+    except AssertionError:
+        traceback.print_exc()
+        raise
+
 def test_YumInstaller():
     from rosdep2.platforms.redhat import YumInstaller
 


### PR DESCRIPTION
First commit makes `rosdep` try to use the python API for RPM when detecting packages. If it can't import it (which should never happen), it will fall back to using the current command-based method. The RPM python module is a C extension, and runs quite a bit faster than parsing command line output.

The second commit adds support for the upcoming DNF package manager in Fedora. Eventually we'll want to make this the default installer for F21+, but we'll cross that bridge when we come to it.
