### PR TITLE
Linaro support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version=__version__,
     packages=['rosdep2', 'rosdep2.platforms'],
     package_dir={'': 'src'},
-    install_requires=['catkin_pkg', 'rospkg', 'rosdistro >= 0.4.0', 'PyYAML >= 3.1'],
+    install_requires=['catkin_pkg', 'rospkg >= 1.0.34', 'rosdistro >= 0.4.0', 'PyYAML >= 3.1'],
     setup_requires=['nose >= 1.0'],
     test_suite='nose.collector',
     test_requires=['mock'],

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -28,7 +28,10 @@
 
 # Author Tully Foote, Ken Conley
 
-from rospkg.os_detect import OS_DEBIAN, OS_UBUNTU, OsDetect
+from __future__ import print_function
+import sys
+
+from rospkg.os_detect import OS_DEBIAN, OS_LINARO, OS_UBUNTU, OsDetect
 
 from .pip import PIP_INSTALLER
 from .gem import GEM_INSTALLER
@@ -44,6 +47,7 @@ def register_installers(context):
 
 def register_platforms(context):
     register_debian(context)
+    register_linaro(context)
     register_ubuntu(context)
     
 def register_debian(context):
@@ -54,6 +58,13 @@ def register_debian(context):
     context.set_default_os_installer_key(OS_DEBIAN, APT_INSTALLER)
     context.set_os_version_type(OS_DEBIAN, OsDetect.get_codename)
     
+def register_linaro(context):
+    # Linaro is an alias for Ubuntu. If linaro is detected and it's not set as an override force ubuntu.
+    (os_name, os_version) = context.get_os_name_and_version()
+    if os_name == OS_LINARO and not context.os_override:
+        print("rosdep detected OS: [%s] aliasing it to: [%s]" % (OS_LINARO, OS_UBUNTU), file=sys.stderr)
+        context.set_os_override(OS_UBUNTU, context.os_detect.get_codename())
+
 def register_ubuntu(context):
     context.add_os_installer_key(OS_UBUNTU, APT_INSTALLER)
     context.add_os_installer_key(OS_UBUNTU, PIP_INSTALLER)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-Depends: python-rospkg, python-yaml, python-catkin-pkg, python-rosdistro (>= 0.4.0)
-Depends3: python3-rospkg, python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0)
+Depends: python-rospkg (>= 1.0.34), python-yaml, python-catkin-pkg, python-rosdistro (>= 0.4.0)
+Depends3: python3-rospkg (>= 1.0.34), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0)
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wheezy jessie
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Add an alias for linaro to ubuntu. It will only trigger if the OS is not overridden. (This does not resolve: #10 it only works with --os overrides)

This looks like a potential solution for #272 and similar issues #366 

