### PR TITLE
pip: fallback to pip show to detect things like argparse

### DIFF
--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -67,6 +67,18 @@ def pip_detect(pkgs, exec_fn=None):
         pkg_row = pkg.split("==")
         if pkg_row[0] in pkgs:
             ret_list.append(pkg_row[0])
+
+    # Try to detect with the return code of `pip show`.
+    # This can show the existance of things like `argparse` which
+    # otherwise do not show up.
+    # See:
+    #   https://github.com/pypa/pip/issues/1570#issuecomment-71111030
+    left_over_list = [x for x in pkgs if x not in ret_list]
+    for pkg in left_over_list:
+        if subprocess.call(['pip', 'show', '-q', pkg]) == 0:
+            # `pip show` detected it, add it to the list.
+            ret_list.append(pkg)
+
     return ret_list
 
 

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -58,8 +58,10 @@ def pip_detect(pkgs, exec_fn=None):
 
     :param exec_fn: function to execute Popen and read stdout (for testing)
     """
+    fallback_to_pip_show = False
     if exec_fn is None:
         exec_fn = read_stdout
+        fallback_to_pip_show = True
     pkg_list = exec_fn(['pip', 'freeze']).split('\n')
 
     ret_list = []
@@ -73,11 +75,11 @@ def pip_detect(pkgs, exec_fn=None):
     # otherwise do not show up.
     # See:
     #   https://github.com/pypa/pip/issues/1570#issuecomment-71111030
-    left_over_list = [x for x in pkgs if x not in ret_list]
-    for pkg in left_over_list:
-        if subprocess.call(['pip', 'show', '-q', pkg]) == 0:
-            # `pip show` detected it, add it to the list.
-            ret_list.append(pkg)
+    if fallback_to_pip_show:
+        for pkg in [p for p in pkgs if p not in ret_list]:
+            if subprocess.call(['pip', 'show', '-q', pkg]) == 0:
+                # `pip show` detected it, add it to the list.
+                ret_list.append(pkg)
 
     return ret_list
 


### PR DESCRIPTION
This is designed to address #368 based on the feedback https://github.com/pypa/pip/issues/1570#issuecomment-71166391. This is the workaround until they decide to change the behavior of `pip show` or until they provide some other mechanism to detect these things.

Fixes #368