### PR TITLE
Warn missing ROS_DISTRO env var that can lead to rosdep keys resolution failure.

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -630,7 +630,10 @@ def command_install(lookup, packages, options):
         print("uninstalled dependencies are: [%s]"%(', '.join([', '.join(pkg) for pkg in [v for k,v in uninstalled]])))
         
     if errors:
-        print("ERROR: the following packages/stacks could not have their rosdep keys resolved\nto system dependencies:", file=sys.stderr)
+        _msg_no_rosdistro_envvar = None
+        if rospkg.distro.current_distro_codename() is None:
+            _msg_no_rosdistro_envvar = " (Could not find current distro codename. Make sure `ROS_DISTRO` environment variable is set, or use `--rosdistro` option to specify the distro (eg. `--rosdistro indigo`))"
+        print("ERROR: the following packages/stacks could not have their rosdep keys resolved\nto system dependencies" + _msg_no_rosdistro_envvar + ":", file=sys.stderr)
         for rosdep_key, error in errors.items():
             print("%s: %s"%(rosdep_key, error_to_human_readable(error)), file=sys.stderr)
         if options.robust:


### PR DESCRIPTION
(Originally discussed in https://github.com/tork-a/ros_seminar/issues/14)

When `ROS_DISTRO` is missing `rosdep install` can fail, which can be easilly fixed by sourcing setup.bash but often not obvious.

```
ubuntu@ubuntu:~/catkin_ws$ sudo rosdep init
Wrote /etc/ros/rosdep/sources.list.d/20-default.list
Recommended: please run

	rosdep update

ubuntu@ubuntu:~/catkin_ws$ rosdep update
reading in sources list data from /etc/ros/rosdep/sources.list.d
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
Add distro "groovy"
Add distro "hydro"
Add distro "indigo"
Add distro "jade"
updated cache in /home/ubuntu/.ros/rosdep/sources.cache
ubuntu@ubuntu:~/catkin_ws$ rosdep install --from-paths src --ignore-src -r -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
stackit_robot_description: Cannot locate rosdep definition for [xacro]
my_onedof_control: Cannot locate rosdep definition for [dynamixel_controllers]
my_moveit_sample: Cannot locate rosdep definition for [rospy]
stackit_robot_ikfast_whole_arm_plugin: Cannot locate rosdep definition for [pluginlib]
rospy_tutorials: Cannot locate rosdep definition for [std_msgs]
roscpp_tutorials: Cannot locate rosdep definition for [std_msgs]
turtlesim: Cannot locate rosdep definition for [std_srvs]
stackit_robot: Cannot locate rosdep definition for [dynamixel_controllers]
stackit_robot_moveit_config: Cannot locate rosdep definition for [xacro]
Continuing to install resolvable dependencies...
#All required rosdeps installed successfully
```

This PR warns the env var missing.

```
$ rosdep install --from-paths src --ignore-src -r -y
WARNING: could not find current distro codename, please check ROS_DISTRO environment variable
WARNING: could not find current distro codename, please check ROS_DISTRO environment variable
Continuing to install resolvable dependencies...
#All required rosdeps installed successfully
```
CC @k-okada 