### PR TITLE
commands.rst: Path to sources was incorrect.

### DIFF
--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -33,7 +33,7 @@ Commands
 
 **init**
 
-  Initialize /etc/ros/sources.list.d/ configuration.  May require sudo.
+  Initialize /etc/ros/rosdep/sources.list.d/ configuration.  May require sudo.
 
 **install <stacks-and-packages>...**
 


### PR DESCRIPTION
The actual sources list is at /etc/ros/rosdep/sources.list.d and not /etc/ros/sources.list.d.