### PR TITLE
Fixes for Fedora/DNF

### DIFF
--- a/src/rosdep2/platforms/arch.py
+++ b/src/rosdep2/platforms/arch.py
@@ -42,7 +42,7 @@ def register_installers(context):
 def register_platforms(context):
     context.add_os_installer_key(ARCH_OS_NAME, SOURCE_INSTALLER)
     context.add_os_installer_key(ARCH_OS_NAME, PACMAN_INSTALLER)
-    context.set_default_os_installer_key(ARCH_OS_NAME, PACMAN_INSTALLER)
+    context.set_default_os_installer_key(ARCH_OS_NAME, lambda self: PACMAN_INSTALLER)
 
 def pacman_detect_single(p):
     return not subprocess.call(['pacman', '-Q', p], stdout=subprocess.PIPE, stderr=subprocess.PIPE)    

--- a/src/rosdep2/platforms/cygwin.py
+++ b/src/rosdep2/platforms/cygwin.py
@@ -45,7 +45,7 @@ def register_installers(context):
 def register_platforms(context):
     context.add_os_installer_key(OS_CYGWIN, SOURCE_INSTALLER)
     context.add_os_installer_key(OS_CYGWIN, APT_CYG_INSTALLER)
-    context.set_default_os_installer_key(OS_CYGWIN, APT_CYG_INSTALLER)
+    context.set_default_os_installer_key(OS_CYGWIN, lambda self: APT_CYG_INSTALLER)
 
 def cygcheck_detect_single(p):
     std_out = read_stdout(['cygcheck', '-c', p])

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -55,7 +55,7 @@ def register_debian(context):
     context.add_os_installer_key(OS_DEBIAN, PIP_INSTALLER)
     context.add_os_installer_key(OS_DEBIAN, GEM_INSTALLER)
     context.add_os_installer_key(OS_DEBIAN, SOURCE_INSTALLER)
-    context.set_default_os_installer_key(OS_DEBIAN, APT_INSTALLER)
+    context.set_default_os_installer_key(OS_DEBIAN, lambda self: APT_INSTALLER)
     context.set_os_version_type(OS_DEBIAN, OsDetect.get_codename)
     
 def register_linaro(context):
@@ -70,7 +70,7 @@ def register_ubuntu(context):
     context.add_os_installer_key(OS_UBUNTU, PIP_INSTALLER)
     context.add_os_installer_key(OS_UBUNTU, GEM_INSTALLER)
     context.add_os_installer_key(OS_UBUNTU, SOURCE_INSTALLER)
-    context.set_default_os_installer_key(OS_UBUNTU, APT_INSTALLER)
+    context.set_default_os_installer_key(OS_UBUNTU, lambda self: APT_INSTALLER)
     context.set_os_version_type(OS_UBUNTU, OsDetect.get_codename)
 
 def dpkg_detect(pkgs, exec_fn=None):

--- a/src/rosdep2/platforms/freebsd.py
+++ b/src/rosdep2/platforms/freebsd.py
@@ -45,7 +45,7 @@ def register_installers(context):
 def register_platforms(context):
     context.add_os_installer_key(OS_FREEBSD, SOURCE_INSTALLER)
     context.add_os_installer_key(OS_FREEBSD, PKG_ADD_INSTALLER)
-    context.set_default_os_installer_key(OS_FREEBSD, PKG_ADD_INSTALLER)
+    context.set_default_os_installer_key(OS_FREEBSD, lambda self: PKG_ADD_INSTALLER)
 
 def pkg_info_detect_single(p):
     if p == "builtin":

--- a/src/rosdep2/platforms/gentoo.py
+++ b/src/rosdep2/platforms/gentoo.py
@@ -56,7 +56,7 @@ def register_installers(context):
 def register_platforms(context):
     context.add_os_installer_key(OS_GENTOO, PORTAGE_INSTALLER)
     context.add_os_installer_key(OS_GENTOO, SOURCE_INSTALLER)
-    context.set_default_os_installer_key(OS_GENTOO, PORTAGE_INSTALLER)
+    context.set_default_os_installer_key(OS_GENTOO, lambda self: PORTAGE_INSTALLER)
 
 # Determine whether an atom is already satisfied
 def portage_detect_single(atom, exec_fn = read_stdout ):

--- a/src/rosdep2/platforms/opensuse.py
+++ b/src/rosdep2/platforms/opensuse.py
@@ -43,7 +43,7 @@ def register_installers(context):
 def register_platforms(context):
     context.add_os_installer_key(OS_OPENSUSE, SOURCE_INSTALLER)
     context.add_os_installer_key(OS_OPENSUSE, ZYPPER_INSTALLER)
-    context.set_default_os_installer_key(OS_OPENSUSE, ZYPPER_INSTALLER)
+    context.set_default_os_installer_key(OS_OPENSUSE, lambda self: ZYPPER_INSTALLER)
     
 def rpm_detect(packages):
     installed = []

--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -62,7 +62,7 @@ def register_platforms(context):
     context.add_os_installer_key(OS_OSX, MACPORTS_INSTALLER)
     context.add_os_installer_key(OS_OSX, PIP_INSTALLER)
     context.add_os_installer_key(OS_OSX, SOURCE_INSTALLER)
-    context.set_default_os_installer_key(OS_OSX, BREW_INSTALLER)
+    context.set_default_os_installer_key(OS_OSX, lambda self: BREW_INSTALLER)
     context.set_os_version_type(OS_OSX, OsDetect.get_codename)
 
 def is_port_installed():

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -142,13 +142,13 @@ class DnfInstaller(PackageManagerInstaller):
         if not packages:
             return []
         elif not interactive and quiet:
-            return [['sudo', 'dnf', '--assumeyes', '--quiet', 'install'] + packages]
+            return [self.elevate_priv(['dnf', '--assumeyes', '--quiet', 'install']) + packages]
         elif quiet:
-            return [['sudo', 'dnf', '--quiet', 'install'] + packages]
+            return [self.elevate_priv(['dnf', '--quiet', 'install']) + packages]
         elif not interactive:
-            return [['sudo', 'dnf', '--assumeyes', 'install'] + packages]
+            return [self.elevate_priv(['dnf', '--assumeyes', 'install']) + packages]
         else:
-            return [['sudo', 'dnf', 'install'] + packages]
+            return [self.elevate_priv(['dnf', 'install']) + packages]
 
 
 class YumInstaller(PackageManagerInstaller):

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -57,8 +57,8 @@ def register_fedora(context):
     context.add_os_installer_key(OS_FEDORA, DNF_INSTALLER)
     context.add_os_installer_key(OS_FEDORA, YUM_INSTALLER)
     context.add_os_installer_key(OS_FEDORA, SOURCE_INSTALLER)
-    context.set_default_os_installer_key(OS_FEDORA, lambda self: YUM_INSTALLER)
-    context.set_os_version_type(OS_FEDORA, lambda self: self.get_version() if int(self.get_version()) > 20 else self.get_codename())
+    context.set_default_os_installer_key(OS_FEDORA, lambda self: DNF_INSTALLER if self.get_version().isdigit() and int(self.get_version()) > 21 else YUM_INSTALLER)
+    context.set_os_version_type(OS_FEDORA, lambda self: self.get_version() if self.get_version().isdigit() and int(self.get_version()) > 20 else self.get_codename())
 
 def register_rhel(context):
     context.add_os_installer_key(OS_RHEL, PIP_INSTALLER)

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -57,14 +57,14 @@ def register_fedora(context):
     context.add_os_installer_key(OS_FEDORA, DNF_INSTALLER)
     context.add_os_installer_key(OS_FEDORA, YUM_INSTALLER)
     context.add_os_installer_key(OS_FEDORA, SOURCE_INSTALLER)
-    context.set_default_os_installer_key(OS_FEDORA, YUM_INSTALLER)
+    context.set_default_os_installer_key(OS_FEDORA, lambda self: YUM_INSTALLER)
     context.set_os_version_type(OS_FEDORA, lambda self: self.get_version() if int(self.get_version()) > 20 else self.get_codename())
 
 def register_rhel(context):
     context.add_os_installer_key(OS_RHEL, PIP_INSTALLER)
     context.add_os_installer_key(OS_RHEL, YUM_INSTALLER)
     context.add_os_installer_key(OS_RHEL, SOURCE_INSTALLER)
-    context.set_default_os_installer_key(OS_RHEL, YUM_INSTALLER)
+    context.set_default_os_installer_key(OS_RHEL, lambda self: YUM_INSTALLER)
 
 def rpm_detect_py(packages):
     ret_list = []

--- a/test/test_rosdep_installers.py
+++ b/test/test_rosdep_installers.py
@@ -216,7 +216,11 @@ def test_InstallerContext_os_installers():
         assert False, "should have raised"
     except KeyError: pass
     try:
-        context.set_default_os_installer_key(os_key, 'fake-key')
+        context.set_default_os_installer_key(os_key, 'non-method')
+        assert False, "should have raised"
+    except KeyError: pass
+    try:
+        context.set_default_os_installer_key(os_key, lambda self: 'fake-key')
         assert False, "should have raised"
     except KeyError: pass
     try:
@@ -241,7 +245,7 @@ def test_InstallerContext_os_installers():
 
     # retest set_default_os_installer_key, now with installer_key not configured on os
     try:
-        context.set_default_os_installer_key(os_key, installer_key2)
+        context.set_default_os_installer_key(os_key, lambda self: installer_key2)
         assert False, "should have raised"
     except KeyError as e:
         assert 'add_os_installer' in str(e), e
@@ -252,14 +256,14 @@ def test_InstallerContext_os_installers():
 
     # test default
     assert None == context.get_default_os_installer_key(os_key)
-    context.set_default_os_installer_key(os_key, installer_key1)
+    context.set_default_os_installer_key(os_key, lambda self: installer_key1)
     assert installer_key1 == context.get_default_os_installer_key(os_key)
-    context.set_default_os_installer_key(os_key, installer_key2)    
+    context.set_default_os_installer_key(os_key, lambda self: installer_key2)
     assert installer_key2 == context.get_default_os_installer_key(os_key)
 
     # retest set_default_os_installer_key, now with invalid os
     try:
-        context.set_default_os_installer_key('bad-os', installer_key1)
+        context.set_default_os_installer_key('bad-os', lambda self: installer_key1)
         assert False, "should have raised"
     except KeyError: pass
 

--- a/test/test_rosdep_redhat.py
+++ b/test/test_rosdep_redhat.py
@@ -104,3 +104,56 @@ def test_YumInstaller():
     except AssertionError:
         traceback.print_exc()
         raise
+
+def test_Fedora_variable_installer_key():
+    from rosdep2 import InstallerContext
+    from rosdep2.platforms import pip, redhat, source
+    from rosdep2.platforms.redhat import DNF_INSTALLER, YUM_INSTALLER
+
+    from rospkg.os_detect import OsDetect, OS_FEDORA
+    os_detect_mock = Mock(spec=OsDetect)
+    os_detect_mock.get_name.return_value = 'fedora'
+    os_detect_mock.get_codename.return_value = 'twenty'
+    os_detect_mock.get_version.return_value = '21'
+
+    # create our test fixture.  use most of the default toolchain, but
+    # replace the apt installer with one that we can have more fun
+    # with.  we will do all tests with ubuntu lucid keys -- other
+    # tests should cover different resolution cases.
+    context = InstallerContext(os_detect_mock)
+    pip.register_installers(context)
+    redhat.register_installers(context)
+    source.register_installers(context)
+    redhat.register_platforms(context)
+
+    assert YUM_INSTALLER == context.get_default_os_installer_key(OS_FEDORA)
+
+    os_detect_mock.get_version.return_value = '22'
+    assert DNF_INSTALLER == context.get_default_os_installer_key(OS_FEDORA)
+
+def test_Fedora_variable_lookup_key():
+    from rosdep2 import InstallerContext
+    from rosdep2.platforms import pip, redhat, source
+    from rosdep2.platforms.redhat import DNF_INSTALLER, YUM_INSTALLER
+
+    from rospkg.os_detect import OsDetect, OS_FEDORA
+    os_detect_mock = Mock(spec=OsDetect)
+    os_detect_mock.get_name.return_value = 'fedora'
+    os_detect_mock.get_codename.return_value = 'heisenbug'
+    os_detect_mock.get_version.return_value = '20'
+
+    # create our test fixture.  use most of the default toolchain, but
+    # replace the apt installer with one that we can have more fun
+    # with.  we will do all tests with ubuntu lucid keys -- other
+    # tests should cover different resolution cases.
+    context = InstallerContext(os_detect_mock)
+    pip.register_installers(context)
+    redhat.register_installers(context)
+    source.register_installers(context)
+    redhat.register_platforms(context)
+
+    assert ('fedora', 'heisenbug') == context.get_os_name_and_version()
+
+    os_detect_mock.get_codename.return_value = 'twenty'
+    os_detect_mock.get_version.return_value = '21'
+    assert (OS_FEDORA, '21') == context.get_os_name_and_version()

--- a/test/test_rosdep_redhat.py
+++ b/test/test_rosdep_redhat.py
@@ -58,16 +58,16 @@ def test_DnfInstaller():
 
         # no interactive option with YUM
         mock_method.return_value = ['a', 'b']
-        expected = [['sudo', 'dnf', '--assumeyes', '--quiet', 'install', 'a', 'b']]
+        expected = [['sudo', '-H', 'dnf', '--assumeyes', '--quiet', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False, quiet=True)
         assert val == expected, val + expected
-        expected = [['sudo', 'dnf', '--quiet', 'install', 'a', 'b']]
+        expected = [['sudo', '-H', 'dnf', '--quiet', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True, quiet=True)
         assert val == expected, val + expected
-        expected = [['sudo', 'dnf', '--assumeyes', 'install', 'a', 'b']]
+        expected = [['sudo', '-H', 'dnf', '--assumeyes', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False, quiet=False)
         assert val == expected, val + expected
-        expected = [['sudo', 'dnf', 'install', 'a', 'b']]
+        expected = [['sudo', '-H', 'dnf', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True, quiet=False)
         assert val == expected, val + expected
     try:


### PR DESCRIPTION
Various fixes for Fedora.

First (and foremost), make DNF the default installer for f22+. This is solved in the same exact manner as the key problem was solved for Fedora 21 (see https://github.com/ros-infrastructure/rosdep/pull/349), so the code should look consistent.

The only API change is that `set_default_os_installer_key` now takes in a method that returns an installer key, instead of just an installer key.

I tested simple resolution, unit tests, and Bloom generation on:
- Fedora 21
- Fedora 22
- Ubuntu Trusty

If @wjwwood could give it a quick once-over from an OSX perspective, that would be great, though I don't anticipate any complications there.

Thanks all,

--scott

Alternate to https://github.com/ros-infrastructure/rosdep/pull/404

Tagging @jpgr87