### PR TITLE
prepend rather than append the paths given by --from-paths to the RPP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
+  - "3.4"
 # command to install dependencies
 install:
 # develop seems to be required by travis since 02/2013

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -414,7 +414,7 @@ class RosdepInstaller(object):
             return uninstalled, errors
         for installer_key, resolved in resolutions: #py3k
             if verbose:
-                print("resolution: %s [%s]"%(installer_key, ', '.join(resolved)))
+                print("resolution: %s [%s]" % (installer_key, ', '.join([str(r) for r in resolved])))
             try:
                 installer = installer_context.get_installer(installer_key)
             except KeyError as e: # lookup has to be buggy to cause this
@@ -429,7 +429,7 @@ class RosdepInstaller(object):
             if packages_to_install:
                 uninstalled.append((installer_key, packages_to_install))
             if verbose:
-                print("uninstalled: [%s]"%(', '.join(packages_to_install)))
+                print("uninstalled: [%s]"%(', '.join([str(p) for p in packages_to_install])))
         
         return uninstalled, errors
     

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -398,7 +398,11 @@ def _package_args_handler(command, parser, options, args):
             if 'ROS_PACKAGE_PATH' not in os.environ:
                 os.environ['ROS_PACKAGE_PATH'] = '{0}'.format(path)
             else:
-                os.environ['ROS_PACKAGE_PATH'] += ':{0}'.format(path)
+                os.environ['ROS_PACKAGE_PATH'] = '{0}{1}{2}'.format(
+                    path,
+                    os.pathsep,
+                    os.environ['ROS_PACKAGE_PATH']
+                )
             pkgs = find_catkin_packages_in(path, options.verbose)
             packages.extend(pkgs)
         # Make packages list unique


### PR DESCRIPTION
This fixes #380 by ensuring that the version of the package in one of the given paths is found before an overlaid copy from the system is found. If you don't ensure this, then new dependencies added to the local copy will not be considered by rosdep, but rather it will use the dependencies of the `package.xml` of the overlaid package from the system.