### PR TITLE
added pip installare to yocto-edison os

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ deb_dist
 dist
 src/rosdep.egg-info
 nose*
+.project
+.pydevproject

--- a/src/rosdep2/platforms/yocto-edison.py
+++ b/src/rosdep2/platforms/yocto-edison.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import subprocess
+
+from rospkg.os_detect import OS_YOCTO_EDISON
+
+from .pip import PIP_INSTALLER
+from ..core import InstallFailed
+from ..installers import PackageManagerInstaller
+from ..shell_utils import read_stdout
+
+def register_platforms(context):
+    context.add_os_installer_key(OS_YOCTO_EDISON, PIP_INSTALLER)


### PR DESCRIPTION
when os_detect is OS_YOCTO_EDISON (see https://github.com/ros-infrastructure/rospkg/pull/86) is need using only pip to install modules
