### PR TITLE
change download url for init.

### DIFF
--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -66,7 +66,7 @@ from .rosdistrohelper import get_index, get_index_url
 
 # default file to download with 'init' command in order to bootstrap
 # rosdep
-DEFAULT_SOURCES_LIST_URL = 'https://raw.github.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list'
+DEFAULT_SOURCES_LIST_URL = 'https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list'
 
 #seconds to wait before aborting download of rosdep data
 DOWNLOAD_TIMEOUT = 15.0


### PR DESCRIPTION
Fixes #426 
Using the new githubusercontent.com url. 