### PR TITLE
Added Ubuntu Wily (15.10) and Xenial (16.04)

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-rospkg (>= 1.0.37), python-yaml, python-catkin-pkg, python-rosdi
 Depends3: python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0)
 Conflicts: python3-rosdep
 Conflicts3: python-rosdep
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wheezy jessie
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial wheezy jessie
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Added Ubuntu Wily (15.10) and Xenial (16.04) to the list of supported platforms.