### PR TITLE
Default to urllib2 to make urlopen more robust

### DIFF
--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -35,11 +35,11 @@ import tempfile
 import yaml
 import hashlib
 try:
-    from urllib.request import urlopen
-    from urllib.error import URLError
-except ImportError:
     from urllib2 import urlopen
     from urllib2 import URLError
+except ImportError:
+    from urllib.request import urlopen
+    from urllib.error import URLError
 try:
     import cPickle as pickle
 except ImportError:


### PR DESCRIPTION
With urllib (HTTP/1.0) rosdep update intermittently fails:

``` bash
$ for i in $(seq 1 100); do rosdep update; done
```

With urllib2 (HTTP/1.1) it doesn't (at least on my tests):

``` python
$ ipython
In [1]: from rosdep2.main import rosdep_main
In [2]: while True:
    rosdep_main(["update"])
```

See this too (there's probably a better reference):
http://stackoverflow.com/questions/9422231/why-does-urllib-urlopenurl-fail-while-urllib2-urlopenurl-works-what-specifi