### PR TITLE
ca-certificates are needed to successfully pull https urls

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-rospkg (>= 1.0.37), python-yaml, python-catkin-pkg, python-rosdistro (>= 0.4.0)
-Depends3: python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0)
+Depends: ca-certificates, python-rospkg (>= 1.0.37), python-yaml, python-catkin-pkg, python-rosdistro (>= 0.4.0)
+Depends3: ca-certificates, python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0)
 Conflicts: python3-rosdep
 Conflicts3: python-rosdep
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial wheezy jessie


### PR DESCRIPTION
This is now enforced in python 2.7.9 and higher (packaged by default in xenial). This means that rosdep cannot run init or update w/o ca-certificates installed which makes it a dependency.

Without this our bootstrapping instructions fail on xenial

Failure when trying to run w/o ca-certificates installed:
```
root@838546e227ad:/# rosdep init 
ERROR: cannot download default sources list from:
https://raw.github.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list
Website may be down.
```