### PR TITLE
Added python version consistency check.

### DIFF
--- a/src/rosdep2/__init__.py
+++ b/src/rosdep2/__init__.py
@@ -66,8 +66,9 @@ def create_default_installer_context(verbose=False):
     from .platforms import redhat
     from .platforms import slackware
     from .platforms import source
+    from .platforms import yocto
 
-    platform_mods = [arch, cygwin, debian, gentoo, opensuse, osx, redhat, slackware]
+    platform_mods = [arch, cygwin, debian, gentoo, opensuse, osx, redhat, slackware, yocto]
     installer_mods = [source, pip, gem] + platform_mods
 
     context = InstallerContext()

--- a/test/test_rosdep_yocto.py
+++ b/test/test_rosdep_yocto.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Author Hunter L. Allen/hunter@openrobotics.org


### PR DESCRIPTION
Fix #379 Inspired by #457 

This checks for python version consistency. A new line is introduced to the cache's index file with the system python version. Should the system python version change, the error doesn't talk about pickles now!

For example (starting with a clean rosdep cache and python version 2.7):

```
allenh1@localhost ~/.ros/rosdep
$ cat sources.cache/index 
# autogenerated by rosdep, do not edit. use 'rosdep update' instead
# Python version 2.7
yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml osx
yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml 
yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml 
yaml https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml 
yaml https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml fuerte
yaml https://raw.githubusercontent.com/ros/rosdistro/master/groovy/distribution.yaml groovy
yaml https://raw.githubusercontent.com/ros/rosdistro/master/hydro/distribution.yaml hydro
yaml https://raw.githubusercontent.com/ros/rosdistro/master/indigo/distribution.yaml indigo
yaml https://raw.githubusercontent.com/ros/rosdistro/master/jade/distribution.yaml jade
yaml https://raw.githubusercontent.com/ros/rosdistro/master/kinetic/distribution.yaml kinetic
```

```
allenh1@localhost ~/CS/rosdep/scripts
$ ./rosdep update
reading in sources list data from /etc/ros/rosdep/sources.list.d
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
Add distro "groovy"
Add distro "hydro"
Add distro "indigo"
Add distro "jade"
Add distro "kinetic"
updated cache in /home/allenh1/.ros/rosdep/sources.cache
```

Upon changing the python version:

```
allenh1@localhost ~/CS/rosdep/scripts
$ python --version
Python 3.4.3
allenh1@localhost ~/CS/rosdep/scripts
$ rosdep update
reading in sources list data from /etc/ros/rosdep/sources.list.d
ERROR: invalid sources list file:
    incompatible python version detected:
cached version is 2.7 but system version is 3.4.
Please remove the current cache and re-run rosdep update.
```
