### PR TITLE
Slackware sbotools and slackpkg installers

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -23,6 +23,7 @@
     <li>Red Hat Enterprise Linux (rpm/experimental)</li>
     <li>Arch (pacman/experimental)</li>
     <li>Gentoo (equery/experimental)</li>
+    <li>Slackware (sbotools/experimental)</li>
     <li>Cygwin (experimental)</li>
     </ul>
     

--- a/src/rosdep2/__init__.py
+++ b/src/rosdep2/__init__.py
@@ -64,9 +64,10 @@ def create_default_installer_context(verbose=False):
     from .platforms import pip
     from .platforms import gem
     from .platforms import redhat
+    from .platforms import slackware
     from .platforms import source
 
-    platform_mods = [arch, cygwin, debian, gentoo, opensuse, osx, redhat]
+    platform_mods = [arch, cygwin, debian, gentoo, opensuse, osx, redhat, slackware]
     installer_mods = [source, pip, gem] + platform_mods
 
     context = InstallerContext()

--- a/src/rosdep2/platforms/slackware.py
+++ b/src/rosdep2/platforms/slackware.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# Copyright (c) 2009, Willow Garage, Inc.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Author Nikolay Nikolov/niko.b.nikolov@gmail.com
+
+import subprocess
+import os
+
+from ..core import InstallFailed
+from .pip import PIP_INSTALLER
+from ..installers import PackageManagerInstaller
+from .source import SOURCE_INSTALLER
+from ..shell_utils import read_stdout
+
+SLACKWARE_OS_NAME = 'slackware'
+SBOTOOLS_INSTALLER = 'sbotools'
+SLACKPKG_INSTALLER = 'slackpkg'
+
+
+def register_installers(context):
+    context.set_installer(SBOTOOLS_INSTALLER, SbotoolsInstaller())
+    context.set_installer(SLACKPKG_INSTALLER, SlackpkgInstaller())
+    
+def register_platforms(context):
+    context.add_os_installer_key(SLACKWARE_OS_NAME, SBOTOOLS_INSTALLER)
+    context.add_os_installer_key(SLACKWARE_OS_NAME, PIP_INSTALLER)
+    context.add_os_installer_key(SLACKWARE_OS_NAME, SOURCE_INSTALLER)
+    context.add_os_installer_key(SLACKWARE_OS_NAME, SLACKPKG_INSTALLER)
+    context.set_default_os_installer_key(SLACKWARE_OS_NAME, lambda self: SBOTOOLS_INSTALLER)
+
+def sbotools_available():
+    if not os.path.exists("/usr/sbin/sboinstall"):
+        return False
+    return True
+
+def sbotools_detect_single(p):
+    pkg_list = read_stdout(['ls', '/var/log/packages'])
+    p = subprocess.Popen(['grep', '-i', '^' + p], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p.communicate(pkg_list)
+    return not p.returncode
+
+def sbotools_detect(packages):
+    return [p for p in packages if sbotools_detect_single(p)]
+
+class SbotoolsInstaller(PackageManagerInstaller):
+
+    def __init__(self):
+        super(SbotoolsInstaller, self).__init__(sbotools_detect)
+
+    def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
+        if not sbotools_available():
+            raise InstallFailed((SBOTOOLS_INSTALLER, "sbotools is not installed"))
+
+        packages = self.get_packages_to_install(resolved, reinstall=reinstall)        
+        if not packages:
+            return []
+
+        cmd = ['sboinstall']
+
+        if not interactive:
+            cmd.append('-r')
+
+        return [self.elevate_priv(cmd + [p]) for p in packages]
+
+def slackpkg_available():
+    if not os.path.exists("/usr/sbin/slackpkg"):
+        return False
+    return True
+
+def slackpkg_detect_single(p):
+    return not subprocess.call(['slackpkg', 'search', p], stdout=subprocess.PIPE, stderr=subprocess.PIPE)    
+
+def slackpkg_detect(packages):
+    return [p for p in packages if slackpkg_detect_single(p)]
+
+class SlackpkgInstaller(PackageManagerInstaller):
+
+    def __init__(self):
+        super(SlackpkgInstaller, self).__init__(slackpkg_detect)
+
+    def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
+        # slackpkg does not provide non-interactive mode
+        packages = self.get_packages_to_install(resolved, reinstall=reinstall)        
+        if not packages:
+            return []
+        else:
+            return [self.elevate_priv(['slackpkg', 'install', p]) for p in packages]

--- a/test/sources_cache/f6f4ef95664e373cd4754501337fa217f5b55d91
+++ b/test/sources_cache/f6f4ef95664e373cd4754501337fa217f5b55d91
@@ -7,6 +7,7 @@ paramiko:
   macports: py26-paramiko
   opensuse: python-paramiko
   ubuntu: python-paramiko
+  slackware: paramiko
 testpython:
   arch: python
   cygwin: python
@@ -16,6 +17,7 @@ testpython:
   gentoo: python
   opensuse: python-devel
   rhel: python-devel
+  slackware: python
   ubuntu: python-dev
   osx:
     homebrew:
@@ -30,6 +32,7 @@ python-gtk2:
   opensuse: python-gtk
   pip: pygtk
   rhel: pygtk2
+  slackware: pygtk
   ubuntu: python-gtk2
 python-imaging:
   arch: python-imaging
@@ -39,6 +42,7 @@ python-imaging:
   gentoo: dev-python/imaging
   opensuse: python-imaging
   rhel: python-imaging
+  slackware: python-pillow
   ubuntu: python-imaging
 python-matplotlib:
   arch: python-matplotlib
@@ -48,4 +52,5 @@ python-matplotlib:
   gentoo: dev-python/matplotlib
   opensuse: python-matplotlib
   rhel: python-matplotlib
+  slackware: matplotlib
   ubuntu: python-matplotlib

--- a/test/test_rosdep_slackware.py
+++ b/test/test_rosdep_slackware.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2011, Willow Garage, Inc.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Author Nikolay Nikolov/niko.b.nikolov@gmail.com
+
+import os
+import traceback
+from mock import Mock, patch
+
+import rospkg.os_detect
+
+def is_slackware():
+    return rospkg.os_detect.Slackware().is_os()
+
+def get_test_dir():
+    # not used yet
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), 'slackware'))
+
+def test_sbotools_available():
+    if not is_slackware():
+        print("Skipping not Slackware")
+        return 
+    from rosdep2.platforms.slackware import sbotools_available
+
+    original_exists = os.path.exists
+
+    path_overrides = {}
+    def mock_path(path):
+        if path in path_overrides:
+            return path_overrides[path]
+        else: 
+            return original_exists(path)
+
+    m = Mock(side_effect=mock_path)
+    os.path.exists = m
+
+    #Test with sbotools missing
+    m.reset_mock()
+    path_overrides = {}
+    path_overrides['/usr/sbin/sboinstall'] = False
+
+    val = sbotools_available()
+    assert val==False, "Sbotools should not be available"
+
+    #Test with sbotools installed
+    m.reset_mock()
+    path_overrides = {}
+    path_overrides['/usr/sbin/sboinstall'] = True
+
+    val = sbotools_available()
+    assert val==True, "Sbotools should be available"
+
+    os.path.exists = original_exists
+
+
+def test_SbotoolsInstaller():
+    if not is_slackware():
+        print("Skipping not Slackware")
+        return 
+
+    from rosdep2.platforms.slackware import SbotoolsInstaller
+
+    @patch.object(SbotoolsInstaller, 'get_packages_to_install')
+    def test(mock_method):
+        installer = SbotoolsInstaller()
+        mock_method.return_value = []
+        assert [] == installer.get_install_command(['fake'])
+
+        mock_method.return_value = ['a', 'b']
+        
+        expected = [['sudo', '-H', 'sboinstall', '-r', 'a'],
+                    ['sudo', '-H', 'sboinstall', '-r', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=False)
+        assert val == expected, val
+
+        expected = [['sudo', '-H', 'sboinstall', 'a'],
+                    ['sudo', '-H', 'sboinstall', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=True)
+        assert val == expected, val
+        
+    try:
+        test()
+    except AssertionError:
+        traceback.print_exc()
+        raise
+    
+def test_slackpkg_available():
+    if not is_slackware():
+        print("Skipping not Slackware")
+        return 
+    from rosdep2.platforms.slackware import slackpkg_available
+
+    original_exists = os.path.exists
+
+    path_overrides = {}
+    def mock_path(path):
+        if path in path_overrides:
+            return path_overrides[path]
+        else: 
+            return original_exists(path)
+
+    m = Mock(side_effect=mock_path)
+    os.path.exists = m
+
+    #Test with sbotools missing
+    m.reset_mock()
+    path_overrides = {}
+    path_overrides['/usr/sbin/slackpkg'] = False
+
+    val = slackpkg_available()
+    assert val==False, "Slackpkg should not be available"
+
+    #Test with sbotools installed
+    m.reset_mock()
+    path_overrides = {}
+    path_overrides['/usr/sbin/slackpkg'] = True
+
+    val = slackpkg_available()
+    assert val==True, "Slackpkg should be available"
+
+    os.path.exists = original_exists
+
+def test_SlackpkgInstaller():
+    if not is_slackware():
+        print("Skipping not Slackware")
+        return 
+
+    from rosdep2.platforms.slackware import SlackpkgInstaller
+
+    @patch.object(SlackpkgInstaller, 'get_packages_to_install')
+    def test(mock_method):
+        installer = SlackpkgInstaller()
+        mock_method.return_value = []
+        assert [] == installer.get_install_command(['fake'])
+
+        mock_method.return_value = ['a', 'b']
+        
+        expected = [['sudo', '-H', 'slackpkg', 'install', 'a'],
+                    ['sudo', '-H', 'slackpkg', 'install', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=False)
+        assert val == expected, val
+
+        expected = [['sudo', '-H', 'slackpkg', 'install', 'a'],
+                    ['sudo', '-H', 'slackpkg', 'install', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=True)
+        assert val == expected, val
+        
+    try:
+        test()
+    except AssertionError:
+        traceback.print_exc()
+        raise
+    


### PR DESCRIPTION
Added support for sbotools and slackpkg installers for Slackware Linux. Added tests. Log from running the tests:

```
niko@dell-xps15: ~/Workspace/rosdep/test $ nosetests test_rosdep_slackware.py
.....
----------------------------------------------------------------------
Ran 5 tests in 0.045s

OK
```