### PR TITLE
Arch Linux: Properly invoke pacman with the correct flags.

### DIFF
--- a/test/test_rosdep_arch.py
+++ b/test/test_rosdep_arch.py
@@ -46,12 +46,10 @@ def test_PacmanInstaller():
 
         # no interactive option implemented yet
         mock_method.return_value = ['a', 'b']
-        expected = [['sudo', '-H', 'pacman', '-Sy', '--needed', 'a'],
-                    ['sudo', '-H', 'pacman', '-Sy', '--needed', 'b']]
+        expected = [['sudo', '-H', 'pacman', '-S', '--noconfirm', '--needed', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False)
         assert val == expected, val
-        expected = [['sudo', '-H', 'pacman', '-Sy', '--needed', 'a'],
-                    ['sudo', '-H', 'pacman', '-Sy', '--needed', 'b']]
+        expected = [['sudo', '-H', 'pacman', '-S', '--needed', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:


### PR DESCRIPTION
This PR fixes the invocation of pacman.

It addresses the following issues:
* The previous implementation used `pacman -Sy`, which can perform a partial upgrade. This is **very much** not what you should do on Arch Linux [1].
* The `interactive` argument was ignored, meaning pacman would always ask for confirmation and rosdep fails when invoked in non-interactive context.
* Additionally it adds `-q` if `quiet == true`, although I believe this currently does not affect the output of `pacman -S`.

[1] https://wiki.archlinux.org/index.php?title=System_maintenance&redirect=no#Partial_upgrades_are_unsupported