### PR TITLE
archlinux: use pacman -T to verify installation

### DIFF
--- a/src/rosdep2/platforms/arch.py
+++ b/src/rosdep2/platforms/arch.py
@@ -45,7 +45,7 @@ def register_platforms(context):
     context.set_default_os_installer_key(ARCH_OS_NAME, lambda self: PACMAN_INSTALLER)
 
 def pacman_detect_single(p):
-    return not subprocess.call(['pacman', '-Q', p], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return not subprocess.call(['pacman', '-T', p], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 def pacman_detect(packages):
     return [p for p in packages if pacman_detect_single(p)]


### PR DESCRIPTION
Currently rosdep uses `pacman -Q` to check if a package is installed. However, that does not work with targets provided by a package of a different name.

For example: the `eigen` package also provides the `eigen3` target. Running `pacman -Q eigen3` will exit non-zero though, because there is no package named `eigen3` installed. Running `pacman -T eigen3` will exit with status 0, because the target `eigen3` is provided by an installed package.

This PR changes rosdep to use `pacman -T`.

`pacman -T` prints the non-installed packages, so it could even be used to implement `pacman_detect` with a single pacman invocation. I didn't think that was worth the added complexity over the current implementation though.