### PR TITLE
Show installers version with --version option

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -376,6 +376,9 @@ class PackageManagerInstaller(Installer):
         '''
         return not self.get_packages_to_install([resolved_item])
 
+    def get_version(self):
+        raise NotImplementedError('subclasses must implement get_version method')
+
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         raise NotImplementedError('subclasses must implement', resolved, interactive, reinstall, quiet)
 

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -321,7 +321,19 @@ def _rosdep_main(args):
 
     options, args = parser.parse_args(args)
     if options.print_version:
-        print(__version__)
+        installers = create_default_installer_context().installers
+        installer_keys = get_default_installer()[1]
+        version_info = ['rosdep version {}'.format(__version__)]
+        for key in installer_keys:
+            installer = installers[key]
+            try:
+                installer_ver = installer.get_version()
+            except Exception:
+                print('{} version unknown'.format(key))
+                continue
+            if installer_ver:
+                version_info.append(installer_ver)
+        print('\n'.join(filter(None, version_info)))
         sys.exit(0)
 
     # flatten list of skipped keys and filter-for-installers

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -29,6 +29,7 @@
 # Author Tully Foote, Ken Conley
 
 from __future__ import print_function
+import subprocess
 import sys
 import re
 
@@ -200,6 +201,11 @@ class AptInstaller(PackageManagerInstaller):
     """
     def __init__(self):
         super(AptInstaller, self).__init__(dpkg_detect)
+
+    def get_version(self):
+        output = subprocess.check_output(['apt-get', '--version'])
+        version = output.splitlines()[0].split(' ')[1]
+        return 'apt-get version {}'.format(version)
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)

--- a/src/rosdep2/platforms/gem.py
+++ b/src/rosdep2/platforms/gem.py
@@ -75,6 +75,10 @@ class GemInstaller(PackageManagerInstaller):
     def __init__(self):
         super(GemInstaller, self).__init__(gem_detect, supports_depends=True)
 
+    def get_version(self):
+        gem_version = subprocess.check_output(['gem', '--version']).strip()
+        return 'gem version {}'.format(gem_version)
+
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         if not is_gem_installed():
             raise InstallFailed((GEM_INSTALLER, "gem is not installed"))

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -30,6 +30,7 @@
 
 from __future__ import print_function
 
+import pkg_resources
 import subprocess
 
 from ..core import InstallFailed
@@ -99,6 +100,15 @@ class PipInstaller(PackageManagerInstaller):
 
     def __init__(self):
         super(PipInstaller, self).__init__(pip_detect, supports_depends=True)
+
+    def get_version(self):
+        pip_version = pkg_resources.get_distribution('pip').version
+        setuptools_version = pkg_resources.get_distribution('setuptools').version
+        version = [
+            'pip version {}'.format(pip_version),
+            'setuptools version {}'.format(setuptools_version),
+        ]
+        return '\n'.join(version)
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         if not is_pip_installed():


### PR DESCRIPTION
Specifically, pip and setuptools version is crucial because
pip distributed on apt is very old on Ubuntu 14.04.
I think showing the version of installer helps user to resolve
their issue caused by old package managing tools.

Usage:

  $ rosdep --version
  source version unknown
  rosdep version 0.11.5
  apt-get version 1.0.1ubuntu2
  pip version 8.1.2
  setuptools version 28.6.1
  gem version 1.8.23
