### PR TITLE
install pip first, then install other methods

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -487,6 +487,8 @@ class RosdepInstaller(object):
                 previous_installer_key = installer_key
             squashed_uninstalled[-1][1].extend(resolved)
 
+        # sort with priority pip = 100, other 0 (smaller installer runs first)
+        squashed_uninstalled.sort(key = lambda e: {'pip': 100}.get(e[0], 0))
         failures = []
         for installer_key, resolved in squashed_uninstalled:
             try:


### PR DESCRIPTION
when we have package that has multiple {run/buidl}_depends with pip and apt (for example), we assume that everything install via apt, then install pip which is not provided from apt
If we install pip first, then pip install everything whcih we assume install via apt

Cc: @wkentaro