### PR TITLE
Fix #495

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -91,7 +91,9 @@ rosdep db
   generate the dependency database and print it to the console.
 
 rosdep init
-  initialize rosdep sources in /etc/ros/rosdep.  May require sudo.
+  initialize rosdep sources in /etc/ros/rosdep. May require sudo.
+  The default can be overridden using the ROS_ETC_DIR environment
+  variable.
   
 rosdep keys <stacks-and-packages>...
   list the rosdep keys that the packages depend on.

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -96,11 +96,7 @@ def get_sources_list_dirs(source_list_dir):
 def get_sources_list_dir():
     # base of where we read config files from
     # TODO: windows
-    if 0:
-        # we can't use etc/ros because environment config does not carry over under sudo
-        etc_ros = rospkg.get_etc_ros_dir()
-    else:
-        etc_ros = '/etc/ros'
+    etc_ros = rospkg.get_etc_ros_dir()
     # compute default system wide sources directory
     sys_sources_list_dir = os.path.join(etc_ros, 'rosdep', SOURCES_LIST_DIR)
     sources_list_dirs = get_sources_list_dirs(sys_sources_list_dir)


### PR DESCRIPTION
- Use rodpkg.get_etc_ros_dir to get the configuration directory path
- Adapt documentation to include instructions for overriding the
default value