### PR TITLE
Extension of #481

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -376,8 +376,14 @@ class PackageManagerInstaller(Installer):
         '''
         return not self.get_packages_to_install([resolved_item])
 
-    def get_version(self):
-        raise NotImplementedError('subclasses must implement get_version method')
+    def get_version_strings(self):
+        '''
+        Return a list of version information strings.
+
+        Where each string is of the form "<installer> <version string>".
+        For example, ["apt-get x.y.z"] or ["pip x.y.z", "setuptools x.y.z"].
+        '''
+        raise NotImplementedError('subclasses must implement get_version_strings method')
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         raise NotImplementedError('subclasses must implement', resolved, interactive, reinstall, quiet)

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -376,6 +376,9 @@ class PackageManagerInstaller(Installer):
         '''
         return not self.get_packages_to_install([resolved_item])
 
+    def get_version(self):
+        raise NotImplementedError('subclasses must implement get_version method')
+
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         raise NotImplementedError('subclasses must implement', resolved, interactive, reinstall, quiet)
 

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -321,7 +321,19 @@ def _rosdep_main(args):
 
     options, args = parser.parse_args(args)
     if options.print_version:
-        print(__version__)
+        installers = create_default_installer_context().installers
+        installer_keys = get_default_installer()[1]
+        version_info = ['rosdep version {}'.format(__version__)]
+        for key in installer_keys:
+            installer = installers[key]
+            try:
+                installer_ver = installer.get_version()
+            except Exception:
+                print('{} version unknown'.format(key))
+                continue
+            if installer_ver:
+                version_info.append(installer_ver)
+        print('\n'.join(filter(None, version_info)))
         sys.exit(0)
 
     # flatten list of skipped keys and filter-for-installers

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -264,7 +264,9 @@ def _rosdep_main(args):
     parser.add_option("--verbose", "-v", dest="verbose", default=False, 
                       action="store_true", help="verbose display")
     parser.add_option("--version", dest="print_version", default=False, 
-                      action="store_true", help="print version and exit")
+                      action="store_true", help="print just the rosdep version, then exit")
+    parser.add_option("--all-versions", dest="print_all_versions", default=False,
+                      action="store_true", help="print rosdep version and version of installers, then exit")
     parser.add_option("--reinstall", dest="reinstall", default=False, 
                       action="store_true", help="(re)install all dependencies, even if already installed")
     parser.add_option("--default-yes", "-y", dest="default_yes", default=False, 
@@ -320,20 +322,35 @@ def _rosdep_main(args):
                       "Can be specified multiple times.")
 
     options, args = parser.parse_args(args)
-    if options.print_version:
+    if options.print_version or options.print_all_versions:
+        # First print the rosdep version.
+        print('{}'.format(__version__))
+        # If not printing versions of all installers, exit.
+        if not options.print_all_versions:
+            sys.exit(0)
+        # Otherwise, Then collect the versions of the installers and print them.
         installers = create_default_installer_context().installers
         installer_keys = get_default_installer()[1]
-        version_info = ['rosdep version {}'.format(__version__)]
+        version_strings = []
         for key in installer_keys:
+            if key is 'source':
+                # Explicitly skip the source installer.
+                continue
             installer = installers[key]
             try:
-                installer_ver = installer.get_version()
-            except Exception:
-                print('{} version unknown'.format(key))
+                installer_version_strings = installer.get_version_strings()
+                assert isinstance(installer_version_strings, list), installer_version_strings
+                version_strings.extend(installer_version_strings)
+            except NotImplementedError:
+                version_strings.append('{} unknown'.format(key))
                 continue
-            if installer_ver:
-                version_info.append(installer_ver)
-        print('\n'.join(filter(None, version_info)))
+        if version_strings:
+            print()
+            print("Versions of installers:")
+            print('\n'.join(['  ' + x for x in version_strings if x]))
+        else:
+            print()
+            print("No installers with versions available found.")
         sys.exit(0)
 
     # flatten list of skipped keys and filter-for-installers

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -202,10 +202,10 @@ class AptInstaller(PackageManagerInstaller):
     def __init__(self):
         super(AptInstaller, self).__init__(dpkg_detect)
 
-    def get_version(self):
+    def get_version_strings(self):
         output = subprocess.check_output(['apt-get', '--version'])
         version = output.splitlines()[0].split(' ')[1]
-        return 'apt-get version {}'.format(version)
+        return ['apt-get {}'.format(version)]
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -29,6 +29,7 @@
 # Author Tully Foote, Ken Conley
 
 from __future__ import print_function
+import subprocess
 import sys
 import re
 
@@ -200,6 +201,11 @@ class AptInstaller(PackageManagerInstaller):
     """
     def __init__(self):
         super(AptInstaller, self).__init__(dpkg_detect)
+
+    def get_version(self):
+        output = subprocess.check_output(['apt-get', '--version'])
+        version = output.splitlines()[0].split(' ')[1]
+        return 'apt-get version {}'.format(version)
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)

--- a/src/rosdep2/platforms/gem.py
+++ b/src/rosdep2/platforms/gem.py
@@ -75,9 +75,9 @@ class GemInstaller(PackageManagerInstaller):
     def __init__(self):
         super(GemInstaller, self).__init__(gem_detect, supports_depends=True)
 
-    def get_version(self):
+    def get_version_strings(self):
         gem_version = subprocess.check_output(['gem', '--version']).strip()
-        return 'gem version {}'.format(gem_version)
+        return ['gem {}'.format(gem_version)]
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         if not is_gem_installed():

--- a/src/rosdep2/platforms/gem.py
+++ b/src/rosdep2/platforms/gem.py
@@ -75,6 +75,10 @@ class GemInstaller(PackageManagerInstaller):
     def __init__(self):
         super(GemInstaller, self).__init__(gem_detect, supports_depends=True)
 
+    def get_version(self):
+        gem_version = subprocess.check_output(['gem', '--version']).strip()
+        return 'gem version {}'.format(gem_version)
+
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         if not is_gem_installed():
             raise InstallFailed((GEM_INSTALLER, "gem is not installed"))

--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -93,6 +93,18 @@ class MacportsInstaller(PackageManagerInstaller):
     def __init__(self):
         super(MacportsInstaller, self).__init__(port_detect)
 
+    def get_version_strings(self):
+        try:
+            p = subprocess.Popen(
+                ['port', 'version'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            version = stdout.replace('Version: ', '')
+            return ['Macports {}'.format(version.strip())]
+        except OSError:
+            return ['Macports not-found']
+
     def get_install_command(self, resolved, interactive=True, reinstall=False):
         if not is_port_installed():
             raise InstallFailed((MACPORTS_INSTALLER, 'MacPorts is not installed'))
@@ -250,6 +262,17 @@ class HomebrewInstaller(PackageManagerInstaller):
     def __init__(self):
         super(HomebrewInstaller, self).__init__(brew_detect, supports_depends=True)
         self.as_root = False
+
+    def get_version_strings(self):
+        try:
+            p = subprocess.Popen(
+                ['brew', '--version'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            return stdout.splitlines()
+        except OSError:
+            return ['Homebrew not-found']
 
     def resolve(self, rosdep_args):
         """

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -101,14 +101,14 @@ class PipInstaller(PackageManagerInstaller):
     def __init__(self):
         super(PipInstaller, self).__init__(pip_detect, supports_depends=True)
 
-    def get_version(self):
+    def get_version_strings(self):
         pip_version = pkg_resources.get_distribution('pip').version
         setuptools_version = pkg_resources.get_distribution('setuptools').version
-        version = [
-            'pip version {}'.format(pip_version),
-            'setuptools version {}'.format(setuptools_version),
+        version_strings = [
+            'pip {}'.format(pip_version),
+            'setuptools {}'.format(setuptools_version),
         ]
-        return '\n'.join(version)
+        return version_strings
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         if not is_pip_installed():

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -30,6 +30,7 @@
 
 from __future__ import print_function
 
+import pkg_resources
 import subprocess
 
 from ..core import InstallFailed
@@ -99,6 +100,15 @@ class PipInstaller(PackageManagerInstaller):
 
     def __init__(self):
         super(PipInstaller, self).__init__(pip_detect, supports_depends=True)
+
+    def get_version(self):
+        pip_version = pkg_resources.get_distribution('pip').version
+        setuptools_version = pkg_resources.get_distribution('setuptools').version
+        version = [
+            'pip version {}'.format(pip_version),
+            'setuptools version {}'.format(setuptools_version),
+        ]
+        return '\n'.join(version)
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         if not is_pip_installed():


### PR DESCRIPTION
I would have pushed directly to #481, but I didn't have permission.

In this extension I:

- restored `--version` to the current behavior
- added `--all-versions` that implements the new behavior
- cleaned up the output formatting
- changed the function name to `get_version_strings` and updated docs to better indicate support for multiple version strings per installer
- added support for Homebrew and Macports

This is what the output looks like on my machine now:

```
william@farl ~
% rosdep --version
0.11.5

william@farl ~
% rosdep --all-versions
0.11.5

Versions of installers:
  Homebrew 1.1.6-45-g9cce341
  Homebrew/homebrew-core (git revision 9c73d; last commit 2017-01-09)
  Macports 2.4.0
  pip 9.0.1
  setuptools 32.3.1
```