### PR TITLE
Added a new test to show up version checking error

### DIFF
--- a/src/rosdep2/rospkg_loader.py
+++ b/src/rosdep2/rospkg_loader.py
@@ -117,6 +117,35 @@ class RosPkgLoader(RosdepLoader):
             self._loadable_resource_cache = list(self._rospack.list())
         return self._loadable_resource_cache
 
+
+    def dep_version_checking(self, deps):
+        names_with_version = []
+        for i in (0, len(deps) - 1):
+            version_values = []
+            try:
+                version_values.append(getattr(deps[i], "version_eq"))
+                version_values.append(getattr(deps[i], "version_gt"))
+                version_values.append(getattr(deps[i], "version_gte"))
+                version_values.append(getattr(deps[i], "version_lt"))
+                version_values.append(getattr(deps[i], "version_lte"))
+            except:
+                print("ERROR: Dependencies version checking has failed,")
+                print("if no version tag has been provided this message can be ignored.")
+                return
+
+            for value in version_values:
+                if (value != None):
+                    names_with_version.append(getattr(deps[i], "name"))
+                    break
+
+        if len(names_with_version) > 0:
+           names_with_version = set(names_with_version)
+           print ("WARNING: The following dependencies have a version specified:")
+           for name in names_with_version:
+                print(name)
+                print ("The version tag(s) provided have been ignoredby rosdep")
+
+
     def get_rosdeps(self, resource_name, implicit=True):
         """
         If *resource_name* is a stack, returns an empty list.
@@ -129,6 +158,7 @@ class RosPkgLoader(RosdepLoader):
                 path = self._rospack.get_path(resource_name)
                 pkg = catkin_pkg.package.parse_package(path)
                 deps = pkg.build_depends + pkg.buildtool_depends + pkg.run_depends + pkg.test_depends
+                self.dep_version_checking(deps)
                 return [d.name for d in deps]
             else:
                 return self._rospack.get_rosdeps(resource_name, implicit=implicit)

--- a/test/test_rosdep_version_checking.py
+++ b/test/test_rosdep_version_checking.py
@@ -1,0 +1,86 @@
+import nose
+import os
+from rosdep2.main import rosdep_main
+from cStringIO import StringIO
+import shutil
+import sys
+from nose.tools import with_setup
+
+
+
+
+
+#This test is simply asking to rosdep to install a version of rospy than does not exist
+#if rosdep print that rosdeps have been successfully met it will fail
+
+package_str = """<?xml version="1.0"?>
+<package format="2">
+  <name>test</name>
+  <version>0.0.1</version>
+
+  <license>BSD</license>
+
+  <description>
+    This is a test...
+  </description>
+
+  <url type="repository">https://fixme.com</url>
+  <url type="bugtracker">https://fixme.com</url>
+
+  <author>Thomas Kostas</author>
+  <author email="tkostas75@gmail.com">yota</author>
+  <maintainer email="tkostas75@gmail.com">yota</maintainer>
+
+
+  <depend version_gte="1984.3.14159265359">rospy</depend>
+
+</package>
+"""
+
+
+def write_data(fd, data):
+    if (fd != None):
+        try:
+            fd.write(data)
+            fd.close()
+        except:
+            raise ValueError("TEST SETUP FAILURE]Failed to setup package file for testing")
+
+def create_file(file_path):
+    fd = None
+    actual_path = os.path.abspath(__file__)
+    directory = os.path.dirname(actual_path)
+    abs_path = directory + file_path
+    directory = os.path.dirname(abs_path)
+
+    if (not os.path.exists(directory)):
+        try:
+            os.makedirs(directory)
+        except:
+            raise ValueError("Failed to setup package file for testing")
+    try:
+        fd = open(abs_path, "w")
+    except:
+        raise ValueError("[TEST SETUP FAILURE]Failed to setup package file for testing")
+    return fd
+
+def setup_function():
+    fd = create_file('/src/package.xml')
+    write_data(fd, package_str)
+
+def teardown_function():
+    actual_path = os.path.abspath(__file__)
+    directory = os.path.dirname(actual_path)
+    directory = directory + '/src'
+    shutil.rmtree(directory)
+
+
+@with_setup(setup_function, teardown_function)
+def test_version_checking():
+    opt = ['install', '--from-path', 'src']
+    my_stdout = StringIO()
+    sys.stdout = my_stdout
+    rosdep_main(opt)
+    sys.stdout = sys.__stdout__
+    if (str(my_stdout.getvalue().strip()) == "#All required rosdeps installed successfully"):
+        raise ValueError("[TEST FAILURE]Version checking has not correctly been done")

--- a/test/test_rosdep_version_checking.py
+++ b/test/test_rosdep_version_checking.py
@@ -6,10 +6,6 @@ import shutil
 import sys
 from nose.tools import with_setup
 
-
-
-
-
 #This test is simply asking to rosdep to install a version of rospy than does not exist
 #if rosdep print that rosdeps have been successfully met it will fail
 


### PR DESCRIPTION
The aim of this test is to show up that rosdep does not care about
the version of the dependencies to be installed in package.xml file.

if rosdep_main function finish with printing:
#All required rosdeps installed successfully
even if package.xml file contains:
depend version_gte="1984.3.14159265359" rospy depend 
the test will be marked as failed.