### PR TITLE
enforce LANG=C in read_stdout

### DIFF
--- a/src/rosdep2/shell_utils.py
+++ b/src/rosdep2/shell_utils.py
@@ -42,6 +42,8 @@ if sys.hexversion > 0x03000000: #Python3
 else:
     python3 = False
 
+env = dict(os.environ)
+env['LANG'] = 'C'
 
 def read_stdout(cmd, capture_stderr=False):
     '''
@@ -56,14 +58,14 @@ def read_stdout(cmd, capture_stderr=False):
     standard error output each as string.
     '''
     if capture_stderr:
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         std_out, std_err = p.communicate()
         if python3:
             return std_out.decode(), std_err.decode()
         else:
             return std_out, std_err
     else:
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env)
         std_out, std_err = p.communicate() # ignore stderr
         if python3:
             return std_out.decode()


### PR DESCRIPTION
The handling of virtual packages (#468) reads the output of certain commands which might be localized and therefore [cannot be matched against](https://github.com/ros-infrastructure/rosdep/blob/master/src/rosdep2/platforms/debian.py#L89). I haven't checked all invocations of `read_stdout`, but forcing `LANG=C` should not affect them.