### PR TITLE
Fix handling of virtual packages

### DIFF
--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -94,7 +94,7 @@ APT_PURELY_VIRTUAL_RE = re.compile(
 APT_CACHE_REVERSE_PROVIDE_START_RE = re.compile(
         r'^Reverse Provides:')
 # format of a 'Reverse Provides' line in the apt-cache showpkg output
-APT_CACHE_PROVIDER_RE = re.compile('^(.*) (.*)$')
+APT_CACHE_PROVIDER_RE = re.compile('^(.*?) (.*)$')
 
 
 def _is_installed_as_virtual_package(package, exec_fn=None):


### PR DESCRIPTION
The output of `apt-cache show` seems to have changed in recent versions.

`docker run --rm ubuntu:trusty bash -c 'apt-get update -qq && apt-cache showpkg linux-kernel-headers` returns
```
[...]
Reverse Provides: 
linux-libc-dev 3.13.0-119.166
linux-libc-dev 3.13.0-24.46
```

But  `docker run --rm ubuntu:xenial bash -c 'apt-get update -qq && apt-cache showpkg linux-kernel-headers` returns
```
[...]
Reverse Provides: 
linux-libc-dev 4.4.0-78.99 (= )
linux-libc-dev 4.4.0-21.37 (= )
```

The patched regular expression matches both correctly.
