### PR TITLE
normalize list of uninstalled to single list of str

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -398,6 +398,18 @@ class PackageManagerInstaller(Installer):
             return rosdep_args.get('depends', [])
         return [] # Default return empty list
 
+
+def normalize_uninstalled_to_list(uninstalled):
+    uninstalled_dependencies = []
+    for pkg_or_list in [v for k, v in uninstalled]:
+        if isinstance(pkg_or_list, list):
+            for pkg in pkg_or_list:
+                uninstalled_dependencies.append(str(pkg))
+        else:
+            uninstalled_dependencies.append(str(pkg))
+    return uninstalled_dependencies
+
+
 class RosdepInstaller(object):
 
     def __init__(self, installer_context, lookup):
@@ -484,8 +496,12 @@ class RosdepInstaller(object):
             installer.install(uninstalled)
         """
         if verbose:
-            print("install options: reinstall[%s] simulate[%s] interactive[%s]"%(reinstall, simulate, interactive))
-            print("install: uninstalled keys are %s"%(', '.join([', '.join(pkg) for pkg in [v for k,v in uninstalled]])))
+            print(
+                "install options: reinstall[%s] simulate[%s] interactive[%s]" %
+                (reinstall, simulate, interactive)
+            )
+            uninstalled_list = normalize_uninstalled_to_list(uninstalled)
+            print("install: uninstalled keys are %s" % ', '.join(uninstalled_list))
 
         # Squash uninstalled again, in case some dependencies were already installed
         squashed_uninstalled = []

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -60,6 +60,7 @@ import rospkg
 from . import create_default_installer_context, get_default_installer
 from . import __version__
 from .core import RosdepInternalError, InstallFailed, UnsupportedOs, InvalidData, CachePermissionError
+from .installers import normalize_uninstalled_to_list
 from .installers import RosdepInstaller
 from .lookup import RosdepLookup, ResolutionError
 from .rospkg_loader import DEFAULT_VIEW_KEY
@@ -660,7 +661,8 @@ def command_install(lookup, packages, options):
         uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose)
 
     if options.verbose:
-        print("uninstalled dependencies are: [%s]"%(', '.join([', '.join(pkg) for pkg in [v for k,v in uninstalled]])))
+        uninstalled_dependencies = normalize_uninstalled_to_list(uninstalled)
+        print("uninstalled dependencies are: [%s]" % ', '.join(uninstalled_dependencies))
 
     if errors:
         err_msg = ("ERROR: the following packages/stacks could not have their "


### PR DESCRIPTION
Fixes: https://github.com/ros-infrastructure/rosdep/issues/524

For the original issue. This just works around the fact that the "uninstalled" is returned in a different data layout in some cases with Homebrew by normalizing it into a list of str's before trying to join it.

I looked at why the data layout is different, but the function declares that the layout is "opaque" as it is passed up from the installer and then back into it again without being used (except to print in verbose mode, which is why this came up). I think the difference is important to the function of the Homebrew implementation. I didn't want to refactor it completely, so I just made the printing functions more flexible.