### PR TITLE
Implement conflict and replace tag

### DIFF
--- a/src/rosdep2/catkin_packages.py
+++ b/src/rosdep2/catkin_packages.py
@@ -11,6 +11,8 @@ except ImportError:
     sys.exit(1)
 
 _catkin_workspace_packages = []
+_catkin_replaced_packages = {}
+_catkin_conflicted_packages = {}
 _catkin_packages_cache = {}
 
 
@@ -32,7 +34,21 @@ def find_catkin_packages_in(path, verbose=False):
         return _catkin_packages_cache[path]
     packages = find_packages(path)
     if type(packages) == dict and packages != {}:
-        package_names = [package.name for package in packages.values()]
+        package_names=[]
+        for package in packages.values():
+            package_names.append(package.name)
+            if package.replaces:
+                for replaced in package.replaces:
+                    if replaced.name in _catkin_replaced_packages:
+                        print("WARNING: '{0}' replaces '{1}', but '{1}' is already replaced by '{2}'".format(
+                            package.name, replaced.name,
+                            _catkin_replaced_packages[replaced.name]))
+                    else:
+                        _catkin_replaced_packages[replaced.name] = package.name
+            if package.conflicts:
+                for conflicted in package.conflicts:
+                    if conflicted.name not in _catkin_conflicted_packages:
+                        _catkin_conflicted_packages[conflicted.name] = package.name
         if verbose:
             print("found " + str(len(packages)) + " packages.")
             for package in package_names:
@@ -53,3 +69,13 @@ def set_workspace_packages(packages):
 def get_workspace_packages():
     global _catkin_workspace_packages
     return _catkin_workspace_packages
+
+
+def get_replaced_packages():
+    global _catkin_replaced_packages
+    return _catkin_replaced_packages
+
+
+def get_conflicted_packages():
+    global _catkin_conflicted_packages
+    return _catkin_conflicted_packages

--- a/src/rosdep2/catkin_packages.py
+++ b/src/rosdep2/catkin_packages.py
@@ -40,7 +40,7 @@ def find_catkin_packages_in(path, verbose=False):
             if package.replaces:
                 for replaced in package.replaces:
                     if replaced.name in _catkin_replaced_packages:
-                        print("WARNING: '{0}' replaces '{1}', but '{1}' is already replaced by '{2}'".format(
+                        print("WARNING: '{0}' replaces '{1}', but '{1}' is already replaced by '{2}'!".format(
                             package.name, replaced.name,
                             _catkin_replaced_packages[replaced.name]))
                     else:
@@ -71,10 +71,32 @@ def get_workspace_packages():
     return _catkin_workspace_packages
 
 
+def add_workspace_packages(resource_name):
+    global _catkin_workspace_packages
+    if resource_name not in _catkin_workspace_packages:
+        _catkin_workspace_packages.append(resource_name)
+
+
 def get_replaced_packages():
     global _catkin_replaced_packages
     return _catkin_replaced_packages
 
+
+def add_replaced_packages(resource_name, replaced_keys):
+    global _catkin_replaced_packages
+    for key in replaced_keys:
+        if key in _catkin_replaced_packages:
+            print("WARNING: '{0}' replaces '{1}', but '{1}' is already replaced by '{2}'!".format(
+                resource_name, key, _catkin_replaced_packages[key]))
+        else:
+            _catkin_replaced_packages[key] = resource_name
+
+
+def add_conflicted_packages(resource_name, conflicted_keys):
+    global _catkin_conflicted_packages
+    for key in conflicted_keys:
+        if key not in _catkin_conflicted_packages:
+            _catkin_conflicted_packages[key] = resource_name
 
 def get_conflicted_packages():
     global _catkin_conflicted_packages

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -36,6 +36,7 @@ import traceback
 from rospkg.os_detect import OsDetect
 
 from .core import rd_debug, RosdepInternalError, InstallFailed, print_bold, InvalidData
+from . import catkin_packages
 
 # kwc: InstallerContext is basically just a bunch of dictionaries with
 # defined lookup methods.  It really encompasses two facets of a
@@ -580,6 +581,7 @@ class RosdepInstaller(object):
             if not installer.is_installed(r):
                 failures.append((installer_key, "Failed to detect successful installation of [%s]"%(r)))
         # finalize result
+        catkin_packages.add_workspace_packages(installer_key)
         if failures:
             raise InstallFailed(failures=failures)
         elif verbose:

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -53,7 +53,7 @@ class RosdepDefinition(object):
     See REP 111, 'Multiple Package Manager Support for Rosdep' for a
     discussion of this raw format.
     """
-    
+
     def __init__(self, rosdep_key, data, origin="<dynamic>"):
         """
         :param rosdep_key: key/name of rosdep dependency
@@ -105,7 +105,7 @@ class RosdepDefinition(object):
             raise ResolutionError(rosdep_key, data, os_name, os_version, "No definition of [%s] for OS [%s]"%(rosdep_key, os_name))
         data = data[os_name]
         return_key = default_installer_key
-        
+
         # REP 111: rosdep first interprets the key as a
         # PACKAGE_MANAGER. If this test fails, it will be interpreted
         # as an OS_VERSION_CODENAME.
@@ -133,7 +133,7 @@ class RosdepDefinition(object):
                         for installer_key in installer_keys:
                             if installer_key in data:
                                 data = data[installer_key]
-                                return_key = installer_key                    
+                                return_key = installer_key
                                 break
 
         if type(data) not in (dict, list, type('str')):
@@ -143,7 +143,7 @@ class RosdepDefinition(object):
 
     def __str__(self):
         return "%s:\n%s"%(self.origin, yaml.dump(self.data, default_flow_style=False))
-    
+
 class ResolutionError(Exception):
 
     def __init__(self, rosdep_key, rosdep_data, os_name, os_version, message):
@@ -171,14 +171,14 @@ class RosdepView(object):
     view merges entries for a particular stack.  This view can then be
     queries to lookup and resolve individual rosdep dependencies.
     """
-    
+
     def __init__(self, name):
         self.name = name
         self.rosdep_defs = {} # {str: RosdepDefinition}
 
     def __str__(self):
         return '\n'.join(["%s: %s"%val for val in self.rosdep_defs.items()])
-            
+
     def lookup(self, rosdep_name):
         """
         :returns: :class:`RosdepDefinition`
@@ -191,7 +191,7 @@ class RosdepView(object):
         :returns: list of rosdep names in this view
         """
         return self.rosdep_defs.keys()
-        
+
     def merge(self, update_entry, override=False, verbose=False):
         """
         Merge rosdep database update into main database.  Merge rules
@@ -232,6 +232,31 @@ def prune_catkin_packages(rosdep_keys, verbose=False):
             del rosdep_keys[i]
     return rosdep_keys
 
+def prune_replaced_packages(rosdep_keys, verbose=False):
+    replaced_pkgs = catkin_packages.get_replaced_packages()
+    if not replaced_pkgs:
+        return rosdep_keys
+    for i, rosdep_key in reversed(list(enumerate(rosdep_keys))):
+        if rosdep_key in replaced_pkgs:
+            # If a package is replaced skip the key
+            if verbose:
+                print("rosdep key '{0}' is replaced by '{1}', skipping.".format(rosdep_key, replaced_pkgs[rosdep_key]), file=sys.stderr)
+            del rosdep_keys[i]
+    return rosdep_keys
+
+
+def prune_conflicted_packages(rosdep_keys, verbose=False):
+    workspace_pkgs = catkin_packages.get_workspace_packages()
+    conflicted_pkgs = catkin_packages.get_conflicted_packages()
+    if not conflicted_pkgs:
+        return rosdep_keys
+    for i, rosdep_key in reversed(list(enumerate(rosdep_keys))):
+        if rosdep_key in conflicted_pkgs:
+            # Warn the user about conflicted key
+            print("WARNING: rosdep key '{0}' is conflicted by '{1}', skipping.".format(rosdep_key, conflicted_pkgs[rosdep_key]), file=sys.stderr)
+            del rosdep_keys[i]
+    return rosdep_keys
+
 
 def prune_skipped_packages(rosdep_keys, skipped_keys, verbose=False):
     if not skipped_keys:
@@ -256,7 +281,7 @@ class RosdepLookup(object):
     on the filesystem will not be reflected if the rosdep information
     has already been loaded.
     """
-    
+
     def __init__(self, rosdep_db, loader):
         """
         :param loader: Loader to use for loading rosdep data by stack
@@ -265,10 +290,10 @@ class RosdepLookup(object):
         """
         self.rosdep_db = rosdep_db
         self.loader = loader
-        
+
         self._view_cache = {} # {str: {RosdepView}}
         self._resolve_cache = {} # {str : (os_name, os_version, installer_key, resolution, dependencies)}
-        
+
         # some APIs that deal with the entire environment save errors
         # in to self.errors instead of raising them in order to be
         # robust to single-stack faults.
@@ -281,7 +306,7 @@ class RosdepLookup(object):
 
     def get_loader(self):
         return self.loader
-    
+
     def get_errors(self):
         """
         Retrieve error state for API calls that do not directly report
@@ -292,7 +317,7 @@ class RosdepLookup(object):
         :returns: List of exceptions, ``[Exception]``
         """
         return self.errors[:]
-    
+
     def get_rosdeps(self, resource_name, implicit=True):
         """
         Get rosdeps that *resource_name* (e.g. package) requires.
@@ -307,14 +332,14 @@ class RosdepLookup(object):
     def get_resources_that_need(self, rosdep_name):
         """
         :param rosdep_name: name of rosdep dependency
-        
+
         :returns: list of package names that require rosdep, ``[str]``
         """
         return [k for k in self.loader.get_loadable_resources() if rosdep_name in self.get_rosdeps(k, implicit=False)]
 
     @staticmethod
-    def create_from_rospkg(rospack=None, rosstack=None, 
-                           sources_loader=None, 
+    def create_from_rospkg(rospack=None, rosstack=None,
+                           sources_loader=None,
                            verbose=False):
         """
         Create :class:`RosdepLookup` based on current ROS package
@@ -342,7 +367,7 @@ class RosdepLookup(object):
         # individual sources it can load from.  SourcesListLoader
         # cannot do delayed evaluation of OS setting due to matcher.
         underlay_key = SourcesListLoader.ALL_VIEW_KEY
-            
+
         # Create the rospkg loader on top of the underlay
         loader = RosPkgLoader(rospack=rospack, rosstack=rosstack,
                               underlay_key=underlay_key)
@@ -366,7 +391,7 @@ class RosdepLookup(object):
         :param installer_context: :class:`InstallerContext`
         :param implicit: Install implicit (recursive) dependencies of
             resources.  Default ``False``.
-        
+
         :returns: (resolutions, errors), ``([(str, [str])], {str: ResolutionError})``.  resolutions provides 
           an ordered list of resolution tuples.  A resolution tuple's first element is the installer 
           key (e.g.: apt or homebrew) and the second element is a list of opaque resolution values for that 
@@ -385,6 +410,8 @@ class RosdepLookup(object):
                     print("resolve_all: resource [%s] requires rosdep keys [%s]"%(resource_name, ', '.join(rosdep_keys)), file=sys.stderr)
                 rosdep_keys = prune_catkin_packages(rosdep_keys, self.verbose)
                 rosdep_keys = prune_skipped_packages(rosdep_keys, self.skipped_keys, self.verbose)
+                rosdep_keys = prune_conflicted_packages(rosdep_keys, self.verbose)
+                rosdep_keys = prune_replaced_packages(rosdep_keys, self.verbose)
                 for rosdep_key in rosdep_keys:
                     try:
                         installer_key, resolution, dependencies = \
@@ -444,7 +471,7 @@ class RosdepLookup(object):
 
         view = self.get_rosdep_view_for_resource(resource_name)
         if view is None:
-            raise ResolutionError(rosdep_key, None, os_name, os_version, "[%s] does not have a rosdep view"%(resource_name))   
+            raise ResolutionError(rosdep_key, None, os_name, os_version, "[%s] does not have a rosdep view"%(resource_name))
         try:
             #print("KEYS", view.rosdep_defs.keys())
             definition = view.lookup(rosdep_key)
@@ -478,13 +505,13 @@ class RosdepLookup(object):
         except KeyError:
             raise ResolutionError(rosdep_key, definition.data, os_name, os_version, "Unsupported installer [%s]"%(installer_key))
         resolution = installer.resolve(rosdep_args_dict)
-        dependencies = installer.get_depends(rosdep_args_dict)        
+        dependencies = installer.get_depends(rosdep_args_dict)
 
         # cache value
         self._resolve_cache[rosdep_key] = os_name, os_version, view.name, installer_key, resolution, dependencies
 
         return installer_key, resolution, dependencies
-        
+
     def _load_all_views(self, loader):
         """
         Load all available view keys.  In general, this is equivalent
@@ -493,7 +520,7 @@ class RosdepLookup(object):
         they will be saved in the *errors* field.
 
         :param loader: override self.loader
-        :raises: :exc:`RosdepInternalError` 
+        :raises: :exc:`RosdepInternalError`
         """
         for resource_name in loader.get_loadable_views():
             try:
@@ -502,14 +529,14 @@ class RosdepLookup(object):
                 self.errors.append(e)
             except InvalidData as e:
                 self.errors.append(e)
-        
+
     def _load_view_dependencies(self, view_key, loader):
         """
         Initialize internal :exc:`RosdepDatabase` on demand.  Not
         thread-safe.
 
         :param view_key: name of view to load dependencies for.
-        
+
         :raises: :exc:`rospkg.ResourceNotFound` If view cannot be located
         :raises: :exc:`InvalidData` if view's data is invaid
         :raises: :exc:`RosdepInternalError`
@@ -521,7 +548,7 @@ class RosdepLookup(object):
         try:
             loader.load_view(view_key, db, verbose=self.verbose)
             entry = db.get_view_data(view_key)
-            rd_debug("_load_view_dependencies[%s]: %s"%(view_key, entry.view_dependencies))            
+            rd_debug("_load_view_dependencies[%s]: %s"%(view_key, entry.view_dependencies))
             for d in entry.view_dependencies:
                 self._load_view_dependencies(d, loader)
         except InvalidData:
@@ -533,7 +560,7 @@ class RosdepLookup(object):
             raise
         except KeyError as e:
             raise RosdepInternalError(e)
-    
+
     def create_rosdep_view(self, view_name, view_keys, verbose=False):
         """
         :param view_name: name of view to create
@@ -551,7 +578,7 @@ class RosdepLookup(object):
         if verbose:
             print("View [%s], merged views:\n"%(view_name)+"\n".join([" * %s"%view_key for view_key in view_keys]), file=sys.stderr)
         return view
-    
+
     def get_rosdep_view_for_resource(self, resource_name, verbose=False):
         """
         Get a :class:`RosdepView` for a specific ROS resource *resource_name*.
@@ -563,11 +590,11 @@ class RosdepLookup(object):
 
         :returns: :class:`RosdepView` for specific ROS resource
           *resource_name*, or ``None`` if no view is associated with this resource.
-        
+
         :raises: :exc:`RosdepConflict` if view cannot be created due
           to conflict rosdep definitions.
         :raises: :exc:`rospkg.ResourceNotFound` if *view_key* cannot be located
-        :raises: :exc:`RosdepInternalError` 
+        :raises: :exc:`RosdepInternalError`
         """
         view_key = self.loader.get_view_key(resource_name)
         if not view_key:
@@ -575,18 +602,18 @@ class RosdepLookup(object):
             #for packages that are not in a stack.
             return None
         return self.get_rosdep_view(view_key, verbose=verbose)
-        
+
     def get_rosdep_view(self, view_key, verbose=False):
         """
         Get a :class:`RosdepView` associated with *view_key*.  Views
         can be queries to resolve rosdep keys to definitions.
 
         :param view_key: Name of rosdep view (e.g. ROS stack name), ``str``
-        
+
         :raises: :exc:`RosdepConflict` if view cannot be created due
           to conflict rosdep definitions.
         :raises: :exc:`rospkg.ResourceNotFound` if *view_key* cannot be located
-        :raises: :exc:`RosdepInternalError` 
+        :raises: :exc:`RosdepInternalError`
         """
         if view_key in self._view_cache:
             return self._view_cache[view_key]
@@ -621,7 +648,7 @@ class RosdepLookup(object):
         :param rosdep_name: name of rosdep to lookup
         :returns: list of (stack_name, origin) where rosdep is defined.
 
-        :raises: :exc:`RosdepInternalError` 
+        :raises: :exc:`RosdepInternalError`
         """
         #TODOXXX: change this to return errors object so that caller cannot ignore
         self._load_all_views(self.loader)
@@ -632,5 +659,5 @@ class RosdepLookup(object):
             # not much abstraction in the entry object
             if rosdep_name in entry.rosdep_data:
                 retval.append((view_name, entry.origin))
-            
+
         return retval

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -53,7 +53,7 @@ class RosdepDefinition(object):
     See REP 111, 'Multiple Package Manager Support for Rosdep' for a
     discussion of this raw format.
     """
-
+    
     def __init__(self, rosdep_key, data, origin="<dynamic>"):
         """
         :param rosdep_key: key/name of rosdep dependency
@@ -105,7 +105,7 @@ class RosdepDefinition(object):
             raise ResolutionError(rosdep_key, data, os_name, os_version, "No definition of [%s] for OS [%s]"%(rosdep_key, os_name))
         data = data[os_name]
         return_key = default_installer_key
-
+        
         # REP 111: rosdep first interprets the key as a
         # PACKAGE_MANAGER. If this test fails, it will be interpreted
         # as an OS_VERSION_CODENAME.
@@ -133,7 +133,7 @@ class RosdepDefinition(object):
                         for installer_key in installer_keys:
                             if installer_key in data:
                                 data = data[installer_key]
-                                return_key = installer_key
+                                return_key = installer_key                    
                                 break
 
         if type(data) not in (dict, list, type('str')):
@@ -143,7 +143,7 @@ class RosdepDefinition(object):
 
     def __str__(self):
         return "%s:\n%s"%(self.origin, yaml.dump(self.data, default_flow_style=False))
-
+    
 class ResolutionError(Exception):
 
     def __init__(self, rosdep_key, rosdep_data, os_name, os_version, message):
@@ -171,14 +171,14 @@ class RosdepView(object):
     view merges entries for a particular stack.  This view can then be
     queries to lookup and resolve individual rosdep dependencies.
     """
-
+    
     def __init__(self, name):
         self.name = name
         self.rosdep_defs = {} # {str: RosdepDefinition}
 
     def __str__(self):
         return '\n'.join(["%s: %s"%val for val in self.rosdep_defs.items()])
-
+            
     def lookup(self, rosdep_name):
         """
         :returns: :class:`RosdepDefinition`
@@ -191,7 +191,7 @@ class RosdepView(object):
         :returns: list of rosdep names in this view
         """
         return self.rosdep_defs.keys()
-
+        
     def merge(self, update_entry, override=False, verbose=False):
         """
         Merge rosdep database update into main database.  Merge rules
@@ -231,6 +231,7 @@ def prune_catkin_packages(rosdep_keys, verbose=False):
                       file=sys.stderr)
             del rosdep_keys[i]
     return rosdep_keys
+
 
 def prune_replaced_packages(rosdep_keys, verbose=False):
     replaced_pkgs = catkin_packages.get_replaced_packages()
@@ -281,7 +282,7 @@ class RosdepLookup(object):
     on the filesystem will not be reflected if the rosdep information
     has already been loaded.
     """
-
+    
     def __init__(self, rosdep_db, loader):
         """
         :param loader: Loader to use for loading rosdep data by stack
@@ -290,10 +291,10 @@ class RosdepLookup(object):
         """
         self.rosdep_db = rosdep_db
         self.loader = loader
-
+        
         self._view_cache = {} # {str: {RosdepView}}
         self._resolve_cache = {} # {str : (os_name, os_version, installer_key, resolution, dependencies)}
-
+        
         # some APIs that deal with the entire environment save errors
         # in to self.errors instead of raising them in order to be
         # robust to single-stack faults.
@@ -306,7 +307,7 @@ class RosdepLookup(object):
 
     def get_loader(self):
         return self.loader
-
+    
     def get_errors(self):
         """
         Retrieve error state for API calls that do not directly report
@@ -317,7 +318,7 @@ class RosdepLookup(object):
         :returns: List of exceptions, ``[Exception]``
         """
         return self.errors[:]
-
+    
     def get_rosdeps(self, resource_name, implicit=True):
         """
         Get rosdeps that *resource_name* (e.g. package) requires.
@@ -332,14 +333,14 @@ class RosdepLookup(object):
     def get_resources_that_need(self, rosdep_name):
         """
         :param rosdep_name: name of rosdep dependency
-
+        
         :returns: list of package names that require rosdep, ``[str]``
         """
         return [k for k in self.loader.get_loadable_resources() if rosdep_name in self.get_rosdeps(k, implicit=False)]
 
     @staticmethod
-    def create_from_rospkg(rospack=None, rosstack=None,
-                           sources_loader=None,
+    def create_from_rospkg(rospack=None, rosstack=None, 
+                           sources_loader=None, 
                            verbose=False):
         """
         Create :class:`RosdepLookup` based on current ROS package
@@ -367,7 +368,7 @@ class RosdepLookup(object):
         # individual sources it can load from.  SourcesListLoader
         # cannot do delayed evaluation of OS setting due to matcher.
         underlay_key = SourcesListLoader.ALL_VIEW_KEY
-
+            
         # Create the rospkg loader on top of the underlay
         loader = RosPkgLoader(rospack=rospack, rosstack=rosstack,
                               underlay_key=underlay_key)
@@ -391,7 +392,7 @@ class RosdepLookup(object):
         :param installer_context: :class:`InstallerContext`
         :param implicit: Install implicit (recursive) dependencies of
             resources.  Default ``False``.
-
+        
         :returns: (resolutions, errors), ``([(str, [str])], {str: ResolutionError})``.  resolutions provides 
           an ordered list of resolution tuples.  A resolution tuple's first element is the installer 
           key (e.g.: apt or homebrew) and the second element is a list of opaque resolution values for that 
@@ -410,8 +411,6 @@ class RosdepLookup(object):
                     print("resolve_all: resource [%s] requires rosdep keys [%s]"%(resource_name, ', '.join(rosdep_keys)), file=sys.stderr)
                 rosdep_keys = prune_catkin_packages(rosdep_keys, self.verbose)
                 rosdep_keys = prune_skipped_packages(rosdep_keys, self.skipped_keys, self.verbose)
-                rosdep_keys = prune_conflicted_packages(rosdep_keys, self.verbose)
-                rosdep_keys = prune_replaced_packages(rosdep_keys, self.verbose)
                 for rosdep_key in rosdep_keys:
                     try:
                         installer_key, resolution, dependencies = \
@@ -471,7 +470,7 @@ class RosdepLookup(object):
 
         view = self.get_rosdep_view_for_resource(resource_name)
         if view is None:
-            raise ResolutionError(rosdep_key, None, os_name, os_version, "[%s] does not have a rosdep view"%(resource_name))
+            raise ResolutionError(rosdep_key, None, os_name, os_version, "[%s] does not have a rosdep view"%(resource_name))   
         try:
             #print("KEYS", view.rosdep_defs.keys())
             definition = view.lookup(rosdep_key)
@@ -505,13 +504,13 @@ class RosdepLookup(object):
         except KeyError:
             raise ResolutionError(rosdep_key, definition.data, os_name, os_version, "Unsupported installer [%s]"%(installer_key))
         resolution = installer.resolve(rosdep_args_dict)
-        dependencies = installer.get_depends(rosdep_args_dict)
+        dependencies = installer.get_depends(rosdep_args_dict)        
 
         # cache value
         self._resolve_cache[rosdep_key] = os_name, os_version, view.name, installer_key, resolution, dependencies
 
         return installer_key, resolution, dependencies
-
+        
     def _load_all_views(self, loader):
         """
         Load all available view keys.  In general, this is equivalent
@@ -520,7 +519,7 @@ class RosdepLookup(object):
         they will be saved in the *errors* field.
 
         :param loader: override self.loader
-        :raises: :exc:`RosdepInternalError`
+        :raises: :exc:`RosdepInternalError` 
         """
         for resource_name in loader.get_loadable_views():
             try:
@@ -529,14 +528,14 @@ class RosdepLookup(object):
                 self.errors.append(e)
             except InvalidData as e:
                 self.errors.append(e)
-
+        
     def _load_view_dependencies(self, view_key, loader):
         """
         Initialize internal :exc:`RosdepDatabase` on demand.  Not
         thread-safe.
 
         :param view_key: name of view to load dependencies for.
-
+        
         :raises: :exc:`rospkg.ResourceNotFound` If view cannot be located
         :raises: :exc:`InvalidData` if view's data is invaid
         :raises: :exc:`RosdepInternalError`
@@ -548,7 +547,7 @@ class RosdepLookup(object):
         try:
             loader.load_view(view_key, db, verbose=self.verbose)
             entry = db.get_view_data(view_key)
-            rd_debug("_load_view_dependencies[%s]: %s"%(view_key, entry.view_dependencies))
+            rd_debug("_load_view_dependencies[%s]: %s"%(view_key, entry.view_dependencies))            
             for d in entry.view_dependencies:
                 self._load_view_dependencies(d, loader)
         except InvalidData:
@@ -560,7 +559,7 @@ class RosdepLookup(object):
             raise
         except KeyError as e:
             raise RosdepInternalError(e)
-
+    
     def create_rosdep_view(self, view_name, view_keys, verbose=False):
         """
         :param view_name: name of view to create
@@ -578,7 +577,7 @@ class RosdepLookup(object):
         if verbose:
             print("View [%s], merged views:\n"%(view_name)+"\n".join([" * %s"%view_key for view_key in view_keys]), file=sys.stderr)
         return view
-
+    
     def get_rosdep_view_for_resource(self, resource_name, verbose=False):
         """
         Get a :class:`RosdepView` for a specific ROS resource *resource_name*.
@@ -590,11 +589,11 @@ class RosdepLookup(object):
 
         :returns: :class:`RosdepView` for specific ROS resource
           *resource_name*, or ``None`` if no view is associated with this resource.
-
+        
         :raises: :exc:`RosdepConflict` if view cannot be created due
           to conflict rosdep definitions.
         :raises: :exc:`rospkg.ResourceNotFound` if *view_key* cannot be located
-        :raises: :exc:`RosdepInternalError`
+        :raises: :exc:`RosdepInternalError` 
         """
         view_key = self.loader.get_view_key(resource_name)
         if not view_key:
@@ -602,18 +601,18 @@ class RosdepLookup(object):
             #for packages that are not in a stack.
             return None
         return self.get_rosdep_view(view_key, verbose=verbose)
-
+        
     def get_rosdep_view(self, view_key, verbose=False):
         """
         Get a :class:`RosdepView` associated with *view_key*.  Views
         can be queries to resolve rosdep keys to definitions.
 
         :param view_key: Name of rosdep view (e.g. ROS stack name), ``str``
-
+        
         :raises: :exc:`RosdepConflict` if view cannot be created due
           to conflict rosdep definitions.
         :raises: :exc:`rospkg.ResourceNotFound` if *view_key* cannot be located
-        :raises: :exc:`RosdepInternalError`
+        :raises: :exc:`RosdepInternalError` 
         """
         if view_key in self._view_cache:
             return self._view_cache[view_key]
@@ -648,7 +647,7 @@ class RosdepLookup(object):
         :param rosdep_name: name of rosdep to lookup
         :returns: list of (stack_name, origin) where rosdep is defined.
 
-        :raises: :exc:`RosdepInternalError`
+        :raises: :exc:`RosdepInternalError` 
         """
         #TODOXXX: change this to return errors object so that caller cannot ignore
         self._load_all_views(self.loader)
@@ -659,5 +658,5 @@ class RosdepLookup(object):
             # not much abstraction in the entry object
             if rosdep_name in entry.rosdep_data:
                 retval.append((view_name, entry.origin))
-
+            
         return retval

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -73,6 +73,7 @@ from .rosdistrohelper import PreRep137Warning
 from .catkin_packages import find_catkin_packages_in
 from .catkin_packages import set_workspace_packages
 from .catkin_packages import get_workspace_packages
+from .catkin_packages import get_conflicted_packages
 
 
 class UsageError(Exception):
@@ -461,6 +462,13 @@ def _package_args_handler(command, parser, options, args):
                 print("Skipping non-existent path " + path)
         set_workspace_packages(ws_pkgs)
 
+    # Print installed conflicting packages
+    workspace_pkgs = get_workspace_packages()
+    conflicted_pkgs = get_conflicted_packages()
+    for package in workspace_pkgs:
+        if package in conflicted_pkgs:
+            print("WARNING: conflicting installed packages: '{0}' is conflicting '{1}'!".format(
+                conflicted_pkgs[package], package))
     lookup = _get_default_RosdepLookup(options)
 
     # Handle the --skip-keys option by pretending that they are packages in the catkin workspace

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -404,7 +404,6 @@ def _rosdep_args_handler(command, parser, options, args):
 def _check_package_replaces_conflicts():
     # Print installed conflicting or replaced packages
     workspace_pkgs = get_workspace_packages()
-    print(workspace_pkgs)
     conflicted_pkgs = get_conflicted_packages()
     replaced_pkgs = get_replaced_packages()
 

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -401,6 +401,21 @@ def _rosdep_args_handler(command, parser, options, args):
         return command_handlers[command](args, options)
 
 
+def _check_package_replaces_conflicts():
+    # Print installed conflicting or replaced packages
+    workspace_pkgs = get_workspace_packages()
+    print(workspace_pkgs)
+    conflicted_pkgs = get_conflicted_packages()
+    replaced_pkgs = get_replaced_packages()
+
+    for package in workspace_pkgs:
+        if package in conflicted_pkgs:
+            print("WARNING: conflicting installed packages: '{0}' is conflicting '{1}'!".format(
+                conflicted_pkgs[package], package))
+        if package in replaced_pkgs:
+            print("WARNING: '{0}' replaces '{1}', but '{1}' is already installed!".format(
+                replaced_pkgs[package], package))
+
 def _package_args_handler(command, parser, options, args):
     if options.rosdep_all:
         if args:
@@ -463,20 +478,6 @@ def _package_args_handler(command, parser, options, args):
                 print("Skipping non-existent path " + path)
         set_workspace_packages(ws_pkgs)
 
-    # Print installed conflicting or replaced packages
-    if command in ['install', 'check'] and (options.ignore_src or options.from_paths):
-        workspace_pkgs = get_workspace_packages()
-        conflicted_pkgs = get_conflicted_packages()
-        replaced_pkgs = get_replaced_packages()
-
-        for package in workspace_pkgs:
-            if package in conflicted_pkgs:
-                print("WARNING: conflicting installed packages: '{0}' is conflicting '{1}'!".format(
-                    conflicted_pkgs[package], package))
-            if package in replaced_pkgs:
-                print("WARNING: '{0}' replaces '{1}', but '{1}' is already installed!".format(
-                    replaced_pkgs[package], package))
-
     lookup = _get_default_RosdepLookup(options)
 
     # Handle the --skip-keys option by pretending that they are packages in the catkin workspace
@@ -489,7 +490,6 @@ def _package_args_handler(command, parser, options, args):
         # possible with empty stacks
         print("No packages in arguments, aborting")
         return
-
     return command_handlers[command](lookup, packages, options)
 
 def convert_os_override_option(options_os_override):
@@ -628,19 +628,23 @@ def command_check(lookup, packages, options):
 
     # pretty print the result
     if [v for k, v in uninstalled if v]:
-        print("System dependencies have not been satisified:")
+        print("System dependencies have not been satisfied:")
         for installer_key, resolved in uninstalled:
             if resolved:
                 for r in resolved:
                     print("%s\t%s"%(installer_key, r))
     else:
-        print("All system dependencies have been satisified")
+        print("All system dependencies have been satisfied")
     if errors:
         for package_name, ex in errors.items():
             if isinstance(ex, rospkg.ResourceNotFound):
                 print("ERROR[%s]: resource not found [%s]"%(package_name, ex.args[0]), file=sys.stderr)
             else:
                 print("ERROR[%s]: %s"%(package_name, ex), file=sys.stderr)                
+
+    # check replaces and conflicts
+    _check_package_replaces_conflicts()
+
     if uninstalled:
         return 1
     else:
@@ -701,6 +705,9 @@ def command_install(lookup, packages, options):
         installer.install(uninstalled, **install_options)
         if not options.simulate:
             print("#All required rosdeps installed successfully")
+
+        # check if there is replaces or conflicts
+        _check_package_replaces_conflicts()
         return 0
     except KeyError as e:
         raise RosdepInternalError(e)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -95,16 +95,16 @@ rosdep db
 
 rosdep init
   initialize rosdep sources in /etc/ros/rosdep.  May require sudo.
-
+  
 rosdep keys <stacks-and-packages>...
   list the rosdep keys that the packages depend on.
 
 rosdep resolve <rosdeps>
   resolve <rosdeps> to system dependencies
-
+  
 rosdep update
   update the local rosdep database based on the rosdep sources.
-
+  
 rosdep what-needs <rosdeps>...
   print a list of packages that declare a rosdep on (at least
   one of) <rosdeps>
@@ -119,7 +119,6 @@ rosdep fix-permissions
   "rosdep update" with sudo accidentally.
 """
 
-
 def _get_default_RosdepLookup(options):
     """
     Helper routine for converting command-line options into
@@ -132,7 +131,6 @@ def _get_default_RosdepLookup(options):
     lookup = RosdepLookup.create_from_rospkg(sources_loader=sources_loader)
     lookup.verbose = options.verbose
     return lookup
-
 
 def rosdep_main(args=None):
     if args is None:
@@ -187,14 +185,13 @@ rosdep version: %s
 %s
 """%(e, __version__, traceback.format_exc()), file=sys.stderr)
         sys.exit(1)
-
-
+        
 def check_for_sources_list_init(sources_cache_dir):
     """
     Check to see if sources list and cache are present.
     *sources_cache_dir* alone is enough to pass as the user has the
     option of passing in a cache dir.
-
+    
     If check fails, tell user how to resolve and sys exit.
     """
     commands = []
@@ -208,7 +205,7 @@ def check_for_sources_list_init(sources_cache_dir):
     if not os.path.exists(sources_list_dir):
         commands.insert(0, 'sudo rosdep init')
     else:
-        filelist = [f for f in os.listdir(sources_list_dir) if f.endswith('.list')]
+        filelist = [f for f in os.listdir(sources_list_dir) if f.endswith('.list')]    
         if not filelist:
             commands.insert(0, 'sudo rosdep init')
 
@@ -216,7 +213,7 @@ def check_for_sources_list_init(sources_cache_dir):
         commands = '\n'.join(["    %s"%c for c in commands])
         print("""
 ERROR: your rosdep installation has not been initialized yet.  Please run:
-
+        
 %s
 """%(commands), file=sys.stderr)
         sys.exit(1)
@@ -258,35 +255,34 @@ def setup_proxy_opener():
             opener = build_opener(proxy, auth, HTTPHandler)
             install_opener(opener)
 
-
 def _rosdep_main(args):
-    # sources cache dir is our local database.
+    # sources cache dir is our local database.  
     default_sources_cache = get_sources_cache_dir()
 
     parser = OptionParser(usage=_usage, prog='rosdep')
-    parser.add_option("--os", dest="os_override", default=None,
+    parser.add_option("--os", dest="os_override", default=None, 
                       metavar="OS_NAME:OS_VERSION", help="Override OS name and version (colon-separated), e.g. ubuntu:lucid")
     parser.add_option("-c", "--sources-cache-dir", dest="sources_cache_dir", default=default_sources_cache,
                       metavar='SOURCES_CACHE_DIR', help="Override %s"%(default_sources_cache))
-    parser.add_option("--verbose", "-v", dest="verbose", default=False,
+    parser.add_option("--verbose", "-v", dest="verbose", default=False, 
                       action="store_true", help="verbose display")
-    parser.add_option("--version", dest="print_version", default=False,
+    parser.add_option("--version", dest="print_version", default=False, 
                       action="store_true", help="print just the rosdep version, then exit")
     parser.add_option("--all-versions", dest="print_all_versions", default=False,
                       action="store_true", help="print rosdep version and version of installers, then exit")
-    parser.add_option("--reinstall", dest="reinstall", default=False,
+    parser.add_option("--reinstall", dest="reinstall", default=False, 
                       action="store_true", help="(re)install all dependencies, even if already installed")
     parser.add_option("--default-yes", "-y", dest="default_yes", default=False, 
                       action="store_true", help="Tell the package manager to default to y or fail when installing")
-    parser.add_option("--simulate", "-s", dest="simulate", default=False,
+    parser.add_option("--simulate", "-s", dest="simulate", default=False, 
                       action="store_true", help="Simulate install")
-    parser.add_option("-r", dest="robust", default=False,
+    parser.add_option("-r", dest="robust", default=False, 
                       action="store_true", help="Continue installing despite errors.")
-    parser.add_option("-q", dest="quiet", default=False,
+    parser.add_option("-q", dest="quiet", default=False, 
                       action="store_true", help="Quiet. Suppress output except for errors.")
-    parser.add_option("-a", "--all", dest="rosdep_all", default=False,
+    parser.add_option("-a", "--all", dest="rosdep_all", default=False, 
                       action="store_true", help="select all packages")
-    parser.add_option("-n", dest="recursive", default=True,
+    parser.add_option("-n", dest="recursive", default=True, 
                       action="store_false", help="Do not consider implicit/recursive dependencies.  Only valid with 'keys', 'check', and 'install' commands.")
     parser.add_option("--ignore-packages-from-source", "--ignore-src", "-i",
                       dest='ignore_src', default=False, action="store_true",
@@ -384,18 +380,16 @@ def _rosdep_main(args):
     if command in _command_rosdep_args:
         return _rosdep_args_handler(command, parser, options, args)
     elif command in _command_no_args:
-        return _no_args_handler(command, parser, options, args)
+        return _no_args_handler(command, parser, options, args)        
     else:
         return _package_args_handler(command, parser, options, args)
-
 
 def _no_args_handler(command, parser, options, args):
     if args:
         parser.error("command [%s] takes no arguments"%(command))
     else:
         return command_handlers[command](options)
-
-
+    
 def _rosdep_args_handler(command, parser, options, args):
 
     # rosdep keys as args
@@ -498,7 +492,6 @@ def _package_args_handler(command, parser, options, args):
 
     return command_handlers[command](lookup, packages, options)
 
-
 def convert_os_override_option(options_os_override):
     """
     Convert os_override option flag to ``(os_name, os_version)`` tuple, or
@@ -515,8 +508,7 @@ def convert_os_override_option(options_os_override):
     os_name = val[:val.find(':')]
     os_version = val[val.find(':')+1:]
     return os_name, os_version
-
-
+    
 def configure_installer_context(installer_context, options):
     """
     Configure the *installer_context* from *options*.
@@ -534,15 +526,14 @@ def configure_installer_context(installer_context, options):
             installer_context.get_installer(k).as_root = v
         except KeyError:
             raise UsageError("Installer '%s' not defined." % k)
-
-
+    
 def command_init(options):
     try:
         data = download_default_sources_list()
     except URLError as e:
         print("ERROR: cannot download default sources list from:\n%s\nWebsite may be down."%(DEFAULT_SOURCES_LIST_URL))
         return 4
-    # reuse path variable for error message
+    # reuse path variable for error message 
     path = get_sources_list_dir()
     old_umask = os.umask(0o022)
     try:
@@ -564,8 +555,7 @@ def command_init(options):
         return 3
     finally:
         os.umask(old_umask)
-
-
+    
 def command_update(options):
     error_occured = []
     def update_success_handler(data_source):
@@ -583,7 +573,7 @@ def command_update(options):
         print("ERROR: no sources directory exists on the system meaning rosdep has not yet been initialized.\n\nPlease initialize your rosdep with\n\n\tsudo rosdep init\n")
         return 1
 
-    filelist = [f for f in os.listdir(sources_list_dir) if f.endswith('.list')]
+    filelist = [f for f in os.listdir(sources_list_dir) if f.endswith('.list')]    
     if not filelist:
         print("ERROR: no data sources in %s\n\nPlease initialize your rosdep with\n\n\tsudo rosdep init\n"%sources_list_dir, file=sys.stderr)
         return 1
@@ -613,13 +603,12 @@ def command_update(options):
         print("]]]")
         return 1
 
-
+    
 def command_keys(lookup, packages, options):
     lookup = _get_default_RosdepLookup(options)
     rosdep_keys = get_keys(lookup, packages, options.recursive)
     _print_lookup_errors(lookup)
     print('\n'.join(rosdep_keys))
-
 
 def get_keys(lookup, packages, recursive):
     rosdep_keys = []
@@ -628,10 +617,9 @@ def get_keys(lookup, packages, recursive):
         rosdep_keys.extend(deps)
     return set(rosdep_keys)
 
-
 def command_check(lookup, packages, options):
     verbose = options.verbose
-
+    
     installer_context = create_default_installer_context(verbose=verbose)
     configure_installer_context(installer_context, options)
     installer = RosdepInstaller(installer_context, lookup)
@@ -652,12 +640,11 @@ def command_check(lookup, packages, options):
             if isinstance(ex, rospkg.ResourceNotFound):
                 print("ERROR[%s]: resource not found [%s]"%(package_name, ex.args[0]), file=sys.stderr)
             else:
-                print("ERROR[%s]: %s"%(package_name, ex), file=sys.stderr)
+                print("ERROR[%s]: %s"%(package_name, ex), file=sys.stderr)                
     if uninstalled:
         return 1
     else:
         return 0
-
 
 def error_to_human_readable(error):
     if isinstance(error, rospkg.ResourceNotFound):
@@ -666,8 +653,7 @@ def error_to_human_readable(error):
         return "%s"%(error.args[0],)
     else:
         return "%s"%(error,)
-
-
+    
 def command_install(lookup, packages, options):
     # map options
     install_options = dict(interactive=not options.default_yes, verbose=options.verbose,
@@ -723,11 +709,10 @@ def command_install(lookup, packages, options):
         print('\n'.join(["  %s: %s"%(k, m) for k,m in e.failures]), file=sys.stderr)
         return 1
 
-
 def _compute_depdb_output(lookup, packages, options):
     installer_context = create_default_installer_context(verbose=options.verbose)
     os_name, os_version = _detect_os(installer_context, options)
-
+    
     output = "Rosdep dependencies for operating system %s version %s "%(os_name, os_version)
     for stack_name in stacks:
         output += "\nSTACK: %s\n"%(stack_name)
@@ -737,8 +722,7 @@ def _compute_depdb_output(lookup, packages, options):
             resolved = resolve_definition(definition, os_name, os_version)
             output = output + "<<<< %s -> %s >>>>\n"%(rosdep, resolved)
     return output
-
-
+    
 def command_db(options):
     # exact same setup logic as command_resolve, should possibly combine
     lookup = _get_default_RosdepLookup(options)
@@ -773,10 +757,9 @@ def command_db(options):
     #TODO: add command-line option for users to be able to see this.
     #This is useful for platform bringup, but useless for most users
     #as the rosdep db contains numerous, platform-specific keys.
-    if 0:
+    if 0: 
         for error in errors:
             print("WARNING: %s"%(error_to_human_readable(error)), file=sys.stderr)
-
 
 def _print_lookup_errors(lookup):
     for error in lookup.get_errors():
@@ -784,8 +767,7 @@ def _print_lookup_errors(lookup):
             print("WARNING: unable to locate resource %s"%(str(error.args[0])), file=sys.stderr)
         else:
             print("WARNING: %s"%(str(error)), file=sys.stderr)
-
-
+            
 def command_what_needs(args, options):
     lookup = _get_default_RosdepLookup(options)
     packages = []
@@ -794,8 +776,7 @@ def command_what_needs(args, options):
 
     _print_lookup_errors(lookup)
     print('\n'.join(set(packages)))
-
-
+    
 def command_where_defined(args, options):
     lookup = _get_default_RosdepLookup(options)
     locations = []
@@ -810,7 +791,6 @@ def command_where_defined(args, options):
     else:
         print("ERROR: cannot find definition(s) for [%s]"%(', '.join(args)), file=sys.stderr)
         return 1
-
 
 def command_resolve(args, options):
     lookup = _get_default_RosdepLookup(options)
@@ -839,14 +819,13 @@ def command_resolve(args, options):
         print (" ".join([str(r) for r in resolved]))
 
     for error in invalid_key_errors:
-        print("ERROR: no rosdep rule for %s"%(error), file=sys.stderr)
+        print("ERROR: no rosdep rule for %s"%(error), file=sys.stderr)        
 
     for error in lookup.get_errors():
         print("WARNING: %s"%(error_to_human_readable(error)), file=sys.stderr)
 
     if invalid_key_errors:
         return 1 # error exit code
-
 
 def command_fix_permissions(options):
     import os
@@ -906,7 +885,7 @@ command_handlers = {
     # backwards compat
     'what_needs': command_what_needs,
     'where_defined': command_where_defined,
-    'depdb': command_db,
+    'depdb': command_db, 
     }
 
 # commands that accept rosdep names as args
@@ -915,4 +894,6 @@ _command_rosdep_args = ['what-needs', 'what_needs', 'where-defined', 'where_defi
 _command_no_args = ['update', 'init', 'db', 'fix-permissions']
 
 _commands = command_handlers.keys()
+
+
 

--- a/src/rosdep2/rospkg_loader.py
+++ b/src/rosdep2/rospkg_loader.py
@@ -120,7 +120,7 @@ class RosPkgLoader(RosdepLoader):
     def get_rosdeps(self, resource_name, implicit=True):
         """
         If *resource_name* is a stack, returns an empty list.
-        
+
         :raises: :exc:`rospkg.ResourceNotFound` if *resource_name* cannot be found.
         """
         if resource_name in self.get_loadable_resources():
@@ -132,6 +132,48 @@ class RosPkgLoader(RosdepLoader):
                 return [d.name for d in deps]
             else:
                 return self._rospack.get_rosdeps(resource_name, implicit=implicit)
+        elif resource_name in self._rosstack.list():
+            # stacks currently do not have rosdeps of their own, implicit or otherwise
+            return []
+        else:
+            raise rospkg.ResourceNotFound(resource_name)
+
+    def get_replaces(self, resource_name):
+        """
+        If *resource_name* is a stack, returns an empty list.
+
+        :raises: :exc:`rospkg.ResourceNotFound` if *resource_name* cannot be found.
+        """
+        if resource_name in self.get_loadable_resources():
+            m = self._rospack.get_manifest(resource_name)
+            if m.is_catkin:
+                path = self._rospack.get_path(resource_name)
+                pkg = catkin_pkg.package.parse_package(path)
+                replaces = pkg.replaces
+                return [r.name for r in replaces]
+            else:
+                return []
+        elif resource_name in self._rosstack.list():
+            # stacks currently do not have rosdeps of their own, implicit or otherwise
+            return []
+        else:
+            raise rospkg.ResourceNotFound(resource_name)
+
+    def get_conflicts(self, resource_name):
+        """
+        If *resource_name* is a stack, returns an empty list.
+
+        :raises: :exc:`rospkg.ResourceNotFound` if *resource_name* cannot be found.
+        """
+        if resource_name in self.get_loadable_resources():
+            m = self._rospack.get_manifest(resource_name)
+            if m.is_catkin:
+                path = self._rospack.get_path(resource_name)
+                pkg = catkin_pkg.package.parse_package(path)
+                conflicts = pkg.conflicts
+                return [c.name for c in conflicts]
+            else:
+                return []
         elif resource_name in self._rosstack.list():
             # stacks currently do not have rosdeps of their own, implicit or otherwise
             return []

--- a/test/test_rosdep_main.py
+++ b/test/test_rosdep_main.py
@@ -112,7 +112,7 @@ class TestRosdepMain(unittest.TestCase):
                 assert False, "system exit occurred: %s\n%s"%(b[0].getvalue(), b[1].getvalue())
 
             stdout, stderr = b
-            assert stdout.getvalue().strip() == "All system dependencies have been satisified", stdout.getvalue()
+            assert stdout.getvalue().strip() == "All system dependencies have been satisfied", stdout.getvalue()
             assert not stderr.getvalue(), stderr.getvalue()
         try:
             osd = rospkg.os_detect.OsDetect()
@@ -120,7 +120,7 @@ class TestRosdepMain(unittest.TestCase):
             with fakeout() as b:
                 rosdep_main(['check', 'python_dep', '--os', override]+cmd_extras)
                 stdout, stderr = b
-                assert stdout.getvalue().strip() == "All system dependencies have been satisified"
+                assert stdout.getvalue().strip() == "All system dependencies have been satisfied"
                 assert not stderr.getvalue(), stderr.getvalue()
         except SystemExit:
             assert False, "system exit occurred"
@@ -130,7 +130,7 @@ class TestRosdepMain(unittest.TestCase):
             with fakeout() as b:
                 rosdep_main(['check', 'packageless']+cmd_extras)
                 stdout, stderr = b
-                assert stdout.getvalue().strip() == "All system dependencies have been satisified"
+                assert stdout.getvalue().strip() == "All system dependencies have been satisfied"
                 assert not stderr.getvalue(), stderr.getvalue()
         except SystemExit:
             assert False, "system exit occurred"


### PR DESCRIPTION
This is to address #526 

Basic behavior:
- If a package has the replace tag for a key, that rosdep key is skipped.
- If two packages both replace a key, a warning message is printed and the key is skipped

- If a package has the conflict tag for a key. that key is skipped and a warning is generated
- if a package has the conflict tag for a key and that key is already installed, a warning is generated 

It will be up to the user so resolve conflicting replace or conflicts.