### PR TITLE
Fix depends

### DIFF
--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -478,7 +478,7 @@ class RosdepLookup(object):
         except KeyError:
             raise ResolutionError(rosdep_key, definition.data, os_name, os_version, "Unsupported installer [%s]"%(installer_key))
         resolution = installer.resolve(rosdep_args_dict)
-        dependencies = installer.get_depends(rosdep_args_dict)        
+        dependencies = installer.get_depends(rosdep_args_dict)
 
         # cache value
         self._resolve_cache[rosdep_key] = os_name, os_version, view.name, installer_key, resolution, dependencies

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -481,7 +481,8 @@ class RosdepLookup(object):
         dependencies = installer.get_depends(rosdep_args_dict)
 
         # cache value
-        self._resolve_cache[rosdep_key] = os_name, os_version, view.name, installer_key, resolution, dependencies
+        # the dependencies list is copied to prevent mutation before next cache hit
+        self._resolve_cache[rosdep_key] = os_name, os_version, view.name, installer_key, resolution, list(dependencies)
 
         return installer_key, resolution, dependencies
         


### PR DESCRIPTION
Basically on the second hit of the cache the `dependencies` list would be empty, when it was not to begin with. The list is being consumed (`.pop` until empty) to figure out the next step, so coping it just prevents the cached version from being empty on future cache hits for the same key.

Should fix https://github.com/ros-infrastructure/rosdep/issues/494.