### PR TITLE
resolve dependencies of meta-packages

### DIFF
--- a/src/rosdep2/rospkg_loader.py
+++ b/src/rosdep2/rospkg_loader.py
@@ -123,18 +123,24 @@ class RosPkgLoader(RosdepLoader):
         
         :raises: :exc:`rospkg.ResourceNotFound` if *resource_name* cannot be found.
         """
+        def get_catkin_depends(path):
+            pkg = catkin_pkg.package.parse_package(path)
+            deps = pkg.build_depends + pkg.buildtool_depends + pkg.run_depends + pkg.test_depends
+            return [d.name for d in deps]
+
         if resource_name in self.get_loadable_resources():
             m = self._rospack.get_manifest(resource_name)
             if m.is_catkin:
-                path = self._rospack.get_path(resource_name)
-                pkg = catkin_pkg.package.parse_package(path)
-                deps = pkg.build_depends + pkg.buildtool_depends + pkg.run_depends + pkg.test_depends
-                return [d.name for d in deps]
+                return get_catkin_depends(self._rospack.get_path(resource_name))
             else:
                 return self._rospack.get_rosdeps(resource_name, implicit=implicit)
         elif resource_name in self._rosstack.list():
-            # stacks currently do not have rosdeps of their own, implicit or otherwise
-            return []
+            m = self._rosstack.get_manifest(resource_name)
+            if m.is_catkin:
+                return get_catkin_depends(self._rosstack.get_path(resource_name))
+            else:
+                # stacks currently do not have rosdeps of their own, implicit or otherwise
+                return []
         else:
             raise rospkg.ResourceNotFound(resource_name)
 

--- a/test/test_rosdep_lookup.py
+++ b/test/test_rosdep_lookup.py
@@ -66,7 +66,8 @@ def get_test_rospkgs():
     test_dir = get_test_tree_dir()
     ros_root = os.path.join(test_dir, 'ros')
     ros_package_path = os.path.join(test_dir, 'stacks')
-    ros_paths = [ros_root, ros_package_path]
+    catkin_package_path = os.path.join(test_dir, 'catkin')
+    ros_paths = [ros_root, ros_package_path, catkin_package_path]
     rospack = RosPack(ros_paths=ros_paths)
     rosstack = RosStack(ros_paths=ros_paths)
     return rospack, rosstack
@@ -263,6 +264,19 @@ def test_RosdepLookup_get_rosdeps():
     assert set(lookup.get_rosdeps('stack1_p2', implicit=False)) == set(['stack1_dep1', 'stack1_dep2', 'stack1_p2_dep1']), set(lookup.get_rosdeps('stack1_p2'))
     assert set(lookup.get_rosdeps('stack1_p2', implicit=True)) == set(['stack1_dep1', 'stack1_dep2', 'stack1_p1_dep1', 'stack1_p1_dep2', 'stack1_p2_dep1']), set(lookup.get_rosdeps('stack1_p2'))    
     
+    # catkin
+    print(lookup.get_rosdeps('simple_catkin_package'))
+    assert set(lookup.get_rosdeps('simple_catkin_package')) == set(['catkin', 'testboost' ])
+    assert set(lookup.get_rosdeps('simple_catkin_package', implicit=False)) == set(['catkin', 'testboost'])
+
+    print(lookup.get_rosdeps('another_catkin_package'))
+    assert set(lookup.get_rosdeps('another_catkin_package')) == set(['catkin', 'simple_catkin_package' ]) # implicit deps won't get included
+    assert set(lookup.get_rosdeps('another_catkin_package', implicit=False)) == set(['catkin', 'simple_catkin_package'])
+
+    print(lookup.get_rosdeps('metapackage_with_deps'))
+    assert set(lookup.get_rosdeps('metapackage_with_deps')) == set(['catkin', 'simple_catkin_package', 'another_catkin_package']) # implicit deps won't get included
+    assert set(lookup.get_rosdeps('metapackage_with_deps', implicit=False)) == set(['catkin', 'simple_catkin_package', 'another_catkin_package'])
+
 def test_RosdepLookup_get_resources_that_need():
     from rosdep2.lookup import RosdepLookup
     rospack, rosstack = get_test_rospkgs()

--- a/test/test_rosdep_lookup.py
+++ b/test/test_rosdep_lookup.py
@@ -242,7 +242,7 @@ def test_RosdepLookup_get_rosdeps():
     rospack, rosstack = get_test_rospkgs()
     
     sources_loader = create_test_SourcesListLoader()
-    lookup = RosdepLookup.create_from_rospkg(rospack=rospack, rosstack=rospack,
+    lookup = RosdepLookup.create_from_rospkg(rospack=rospack, rosstack=rosstack,
                                              sources_loader=sources_loader)
     assert lookup.get_loader() is not None
     assert isinstance(lookup.get_loader(), RosdepLoader)
@@ -268,7 +268,7 @@ def test_RosdepLookup_get_resources_that_need():
     rospack, rosstack = get_test_rospkgs()
     
     sources_loader = create_test_SourcesListLoader()
-    lookup = RosdepLookup.create_from_rospkg(rospack=rospack, rosstack=rospack,
+    lookup = RosdepLookup.create_from_rospkg(rospack=rospack, rosstack=rosstack,
                                              sources_loader=sources_loader)
 
     assert lookup.get_resources_that_need('fake') ==  []

--- a/test/tree/catkin/another_catkin_package/package.xml
+++ b/test/tree/catkin/another_catkin_package/package.xml
@@ -1,0 +1,14 @@
+
+<package>
+  <name>another_catkin_package</name>
+  <version>0.0.0</version>
+  <description>
+    This is a another package
+  </description>
+  <maintainer email="nobody@example.org">Nobody</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>simple_catkin_package</build_depend>
+</package>

--- a/test/tree/catkin/another_catkin_package/package.xml
+++ b/test/tree/catkin/another_catkin_package/package.xml
@@ -1,4 +1,3 @@
-
 <package>
   <name>another_catkin_package</name>
   <version>0.0.0</version>

--- a/test/tree/catkin/metapackage_with_deps/package.xml
+++ b/test/tree/catkin/metapackage_with_deps/package.xml
@@ -1,0 +1,18 @@
+<package>
+  <name>metapackage_with_deps</name>
+  <version>0.0.0</version>
+  <description>
+    This is a meta-package with depencencies
+  </description>
+  <maintainer email="nobody@example.org">Nobody</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>simple_catkin_package</run_depend>
+  <run_depend>another_catkin_package</run_depend>
+
+  <export>
+    <metapackage />
+  </export>
+</package>

--- a/test/tree/catkin/simple_catkin_package/package.xml
+++ b/test/tree/catkin/simple_catkin_package/package.xml
@@ -1,0 +1,13 @@
+<package>
+  <name>simple_catkin_package</name>
+  <version>0.0.0</version>
+  <description>
+    This is a simple package
+  </description>
+  <maintainer email="nobody@example.org">Nobody</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>testboost</build_depend>
+</package>


### PR DESCRIPTION
fixes #430 

Haven't tested it yet.
For the sake of simplicity meta-package's `build_depends` and `test_depends` get returned as well, even if these should be empty anyway.