### PR TITLE
[fix] Exception with multiple lines only prints the first line.

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -188,7 +188,7 @@ Please go to the rosdep page [1] and file a bug report with the stack trace belo
 rosdep version: %s
 
 %s
-""" % (e, __version__, traceback.format_exc()), file=sys.stderr)
+""" % (e.__str__(), __version__, traceback.format_exc()), file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
[20 lines above already handles multiple lines](https://github.com/ros-infrastructure/rosdep/blob/27d372bc551e346ee72d42c21b102d27371bc0d6/src/rosdep2/main.py#L166).