### PR TITLE
Add __repr__ for SourceInstall

### DIFF
--- a/src/rosdep2/platforms/source.py
+++ b/src/rosdep2/platforms/source.py
@@ -173,6 +173,8 @@ class SourceInstall(object):
 
     def __str__(self):
         return "source: %s"%(self.manifest_url)
+
+    __rep__ = __str__
     
 def is_source_installed(source_item, exec_fn=None):
     return create_tempfile_from_string_and_execute(source_item.check_presence_command, exec_fn=exec_fn)

--- a/src/rosdep2/platforms/source.py
+++ b/src/rosdep2/platforms/source.py
@@ -174,7 +174,7 @@ class SourceInstall(object):
     def __str__(self):
         return "source: %s"%(self.manifest_url)
 
-    __rep__ = __str__
+    __repr__ = __str__
     
 def is_source_installed(source_item, exec_fn=None):
     return create_tempfile_from_string_and_execute(source_item.check_presence_command, exec_fn=exec_fn)


### PR DESCRIPTION
Because `__rep__` is missing on `SourceInstall`, `--verbose` option doesn't work well for source installer (to display list of installers).