### PR TITLE
Keep dependencies order

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -368,7 +368,7 @@ class PackageManagerInstaller(Installer):
         if not resolved:
             return []
         else:
-            return list(set(resolved) - set(self.detect_fn(resolved)))
+            return [x for x in resolved if x not in self.detect_fn(resolved)]
 
     def is_installed(self, resolved_item):
         '''


### PR DESCRIPTION
Because `set` doesn't keep elements order, order of dependency list might be broken.