### PR TITLE
Use ROS_ETC_DIR Variable

### DIFF
--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -96,11 +96,7 @@ def get_sources_list_dirs(source_list_dir):
 def get_sources_list_dir():
     # base of where we read config files from
     # TODO: windows
-    if 0:
-        # we can't use etc/ros because environment config does not carry over under sudo
-        etc_ros = rospkg.get_etc_ros_dir()
-    else:
-        etc_ros = '/etc/ros'
+    etc_ros = rospkg.get_etc_ros_dir()
     # compute default system wide sources directory
     sys_sources_list_dir = os.path.join(etc_ros, 'rosdep', SOURCES_LIST_DIR)
     sources_list_dirs = get_sources_list_dirs(sys_sources_list_dir)


### PR DESCRIPTION
There is a note in the code that says the etc/ros can't be used because the environment config doesn't carry over under sudo, but I don't think this is actually relevant, as seen from the rospkg code below:

https://github.com/ros-infrastructure/rospkg/blob/124658aa9e7aa5b5db61288624b0aa7858f0db91/src/rospkg/environment.py#L213-L227

---

connects to #495