### PR TITLE
remove non-interactive mode in slackware

### DIFF
--- a/src/rosdep2/platforms/slackware.py
+++ b/src/rosdep2/platforms/slackware.py
@@ -82,10 +82,7 @@ class SbotoolsInstaller(PackageManagerInstaller):
 
         cmd = ['sboinstall']
 
-        if not interactive:
-            cmd.append('-r')
-
-        return [self.elevate_priv(cmd + [p]) for p in packages]
+        return [self.elevate_priv(cmd + [p] + ["-j"]) for p in packages]
 
 def slackpkg_available():
     if not os.path.exists("/usr/sbin/slackpkg"):


### PR DESCRIPTION
Removed the non-interactive mode in Slackware as it caused required system dependencies to be skipped. At the moment the Slackware package manager does not support true non-interactive mode.