### PR TITLE
add test for wilcard os version

### DIFF
--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -127,9 +127,15 @@ class RosdepDefinition(object):
                     # we've already checked for PACKAGE_MANAGER_KEY, so
                     # version key must be present here for data to be valid
                     # dictionary value.
+                    if (
+                        # if the os_version has the value None
+                        (os_version in data and data[os_version] is None) or
+                        # or if the os_version is not defined and there is no wildcard
+                        (os_version not in data and '*' not in data)
+                    ):
+                        raise ResolutionError(rosdep_key, self.data, os_name, os_version, 'No definition of [%s] for OS version [%s]' % (rosdep_key, os_version))
+                    # if os version is not defined (and there is a wildcard) fallback to the wildcard
                     if os_version not in data:
-                        if '*' not in data:
-                            raise ResolutionError(rosdep_key, self.data, os_name, os_version, 'No definition of [%s] for OS version [%s]' % (rosdep_key, os_version))
                         os_version = '*'
                     data = data[os_version]
                     if type(data) == dict:

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -128,7 +128,9 @@ class RosdepDefinition(object):
                     # version key must be present here for data to be valid
                     # dictionary value.
                     if os_version not in data:
-                        raise ResolutionError(rosdep_key, self.data, os_name, os_version, 'No definition of [%s] for OS version [%s]' % (rosdep_key, os_version))
+                        if '*' not in data:
+                            raise ResolutionError(rosdep_key, self.data, os_name, os_version, 'No definition of [%s] for OS version [%s]' % (rosdep_key, os_version))
+                        os_version = '*'
                     data = data[os_version]
                     if type(data) == dict:
                         for installer_key in installer_keys:

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -127,13 +127,12 @@ class RosdepDefinition(object):
                     # we've already checked for PACKAGE_MANAGER_KEY, so
                     # version key must be present here for data to be valid
                     # dictionary value.
-                    if (
-                        # if the os_version has the value None
-                        (os_version in data and data[os_version] is None) or
-                        # or if the os_version is not defined and there is no wildcard
-                        (os_version not in data and '*' not in data)
-                    ):
+                    # if the os_version is not defined and there is no wildcard
+                    if os_version not in data and '*' not in data:
                         raise ResolutionError(rosdep_key, self.data, os_name, os_version, 'No definition of [%s] for OS version [%s]' % (rosdep_key, os_version))
+                    # if the os_version has the value None
+                    if os_version in data and data[os_version] is None:
+                        raise ResolutionError(rosdep_key, self.data, os_name, os_version, 'Null definition of [%s] for OS version [%s]' % (rosdep_key, os_version))
                     # if os version is not defined (and there is a wildcard) fallback to the wildcard
                     if os_version not in data:
                         os_version = '*'

--- a/test/test_rosdep_lookup.py
+++ b/test/test_rosdep_lookup.py
@@ -165,7 +165,17 @@ def test_RosdepDefinition():
         # tripwire
         str(e)
 
-    definition = RosdepDefinition('testtinyxml', {'ubuntu': {'precise': ['libtinyxml-dev'], '*': ['libtinyxml2-dev']}}, 'wildcard.txt')
+    definition = RosdepDefinition('testtinyxml', {'ubuntu': {'lucid': None, 'precise': ['libtinyxml-dev'], '*': ['libtinyxml2-dev']}}, 'wildcard.txt')
+    try:
+        val = definition.get_rule_for_platform('ubuntu', 'lucid', ['apt', 'source', 'pip'], 'apt')
+        assert False, 'should have raised: %s' % (str(val))
+    except ResolutionError as e:
+        assert e.rosdep_key == 'testtinyxml'
+        assert e.os_name == 'ubuntu'
+        assert e.os_version == 'lucid'
+        # tripwire
+        str(e)
+
     val = definition.get_rule_for_platform('ubuntu', 'precise', ['apt', 'source', 'pip'], 'apt')
     assert val == ('apt', ['libtinyxml-dev']), val
 

--- a/test/test_rosdep_lookup.py
+++ b/test/test_rosdep_lookup.py
@@ -165,6 +165,13 @@ def test_RosdepDefinition():
         # tripwire
         str(e)
 
+    definition = RosdepDefinition('testtinyxml', {'ubuntu': {'precise': ['libtinyxml-dev'], '*': ['libtinyxml2-dev']}}, 'wildcard.txt')
+    val = definition.get_rule_for_platform('ubuntu', 'precise', ['apt', 'source', 'pip'], 'apt')
+    assert val == ('apt', ['libtinyxml-dev']), val
+
+    val = definition.get_rule_for_platform('ubuntu', 'trusty', ['apt', 'source', 'pip'], 'apt')
+    assert val == ('apt', ['libtinyxml2-dev']), val
+
     # test reverse merging OS things (first is default)
     definition = RosdepDefinition('test', {'debian': 'libtest-dev'}, 'fake-1.txt')
     # rule should work as expected before reverse-merge


### PR DESCRIPTION
While there are many different cases where `rosdep` could be improved this PR targets one specific case which is fairly common.

Many rosdep keys exist with a generic mapping independent of the OS version. This is great since the rule doesn't have to updated for new OS versions as long as the system package name stays the same. But when at some point the system package name does change there are one two choices with the current version of rosdep which are both not optimal:
* Either all OS versions need to be explicitly enumerated and from that point on forward the entry needs to be updated for every new OS version
* or at some point the "old" OS versions before the system package rename are being dropped to collapse the mapping to a generic rule again (in order to not require to update the entry in the future).

This patch solves this specific problem / use case. It adds special semantic to an OS version named `*`. When a specific rule is being looked up and the desired OS version isn't in the dictionary the logic will now check if an OS version `*` is present. If that is the case the data from `*` is being used (instead of failing the lookup).

The approach is strictly less powerful than allowing to define os version ranges (e.g. "xenial-and-newer"). The advantage is that it doesn't require an order on the os versions and solves at least some current use cases *now*.

If this approach is being approved I am happy to either create a PR against [REP 111](http://www.ros.org/reps/rep-0111.html) or create a new REP describing the delta compared to the existing one.