### PR TITLE
Update the FreeBSD Installer

### DIFF
--- a/src/rosdep2/__init__.py
+++ b/src/rosdep2/__init__.py
@@ -64,10 +64,11 @@ def create_default_installer_context(verbose=False):
     from .platforms import pip
     from .platforms import gem
     from .platforms import redhat
+    from .platforms import freebsd
     from .platforms import slackware
     from .platforms import source
 
-    platform_mods = [arch, cygwin, debian, gentoo, opensuse, osx, redhat, slackware]
+    platform_mods = [arch, cygwin, debian, gentoo, opensuse, osx, redhat, slackware, freebsd]
     installer_mods = [source, pip, gem] + platform_mods
 
     context = InstallerContext()

--- a/src/rosdep2/catkin_support.py
+++ b/src/rosdep2/catkin_support.py
@@ -27,6 +27,7 @@ from .platforms.debian import APT_INSTALLER
 from .platforms.osx import BREW_INSTALLER
 from .platforms.pip import PIP_INSTALLER
 from .platforms.redhat import YUM_INSTALLER
+from .platforms.freebsd import PKG_INSTALLER
 from .rep3 import download_targets_data
 from .rosdistrohelper import get_targets
 from .rospkg_loader import DEFAULT_VIEW_KEY

--- a/src/rosdep2/platforms/freebsd.py
+++ b/src/rosdep2/platforms/freebsd.py
@@ -28,65 +28,54 @@
 
 # Original from cygwin.py by Tingfan Wu tingfan@gmail.com
 # Modified for FreeBSD by Rene Ladan rene@freebsd.org
-
-import os
-import subprocess
+# Updated for FreeBSD with pkg by Trenton Schulz trentonw@ifi.uio.no
 
 from rospkg.os_detect import OS_FREEBSD
 
-from .source import SOURCE_INSTALLER
-from ..installers import Installer
+from .pip import PIP_INSTALLER
+from ..installers import PackageManagerInstaller
+from ..shell_utils import read_stdout
 
-PKG_ADD_INSTALLER = 'pkg_add'
+PKG_INSTALLER = 'pkg'
 
 
 def register_installers(context):
-    context.set_installer(PKG_ADD_INSTALLER, PkgAddInstaller())
+    context.set_installer(PKG_INSTALLER, PkgInstaller())
 
 
 def register_platforms(context):
-    context.add_os_installer_key(OS_FREEBSD, SOURCE_INSTALLER)
-    context.add_os_installer_key(OS_FREEBSD, PKG_ADD_INSTALLER)
-    context.set_default_os_installer_key(OS_FREEBSD, lambda self: PKG_ADD_INSTALLER)
+    context.add_os_installer_key(OS_FREEBSD, PKG_INSTALLER)
+    context.add_os_installer_key(OS_FREEBSD, PIP_INSTALLER)
+    context.set_default_os_installer_key(OS_FREEBSD, lambda self: PKG_INSTALLER)
 
 
-def pkg_info_detect_single(p):
-    if p == 'builtin':
+def pkg_detect_single(p, exec_fn):
+    if p == "builtin":
         return True
-    # The next code is a lot of hassle, but there is no
-    # better way in FreeBSD using just the base tools
-    portname = p
-    if p == 'gtk20':
-        portname = 'gtk-2.\*'
-    elif p == 'py-gtk2':
-        portname = 'py27-gtk-2.\*'
-    elif p[:9] in ['autoconf2', 'automake1']:
-        portname = p[:8] + '-' + p[8] + '.' + p[9:] + '\*'
-    elif p[:3] == 'py-':
-        portname = 'py27-' + p[3:] + '\*'
-    else:
-        portname = p + '-\*'
-    pop = subprocess.Popen('/usr/sbin/pkg_info -qE ' + portname, shell=True)
-    return os.waitpid(pop.pid, 0)[1] == 0  # pkg_info -E returns 0 if pkg installed, 1 if not
+
+    cmd = ['/usr/sbin/pkg', 'query', '%n', p]
+    std_out = exec_fn(cmd)
+    return std_out.split() != []
 
 
-def pkg_info_detect(packages):
-    return [p for p in packages if pkg_info_detect_single(p)]
+def pkg_detect(packages, exec_fn=None):
+    if exec_fn is None:
+        exec_fn = read_stdout
+    return [p for p in packages if pkg_detect_single(p, exec_fn)]
 
 
-class PkgAddInstaller(Installer):
+class PkgInstaller(PackageManagerInstaller):
     """
     An implementation of the Installer for use on FreeBSD-style
     systems.
     """
 
     def __init__(self):
-        super(PkgAddInstaller, self).__init__(pkg_info_detect)
+        super(PkgInstaller, self).__init__(pkg_detect)
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)
         if not packages:
             return []
         else:
-            # pkg_add does not have a non-interactive command
-            return [self.elevate_priv(['/usr/sbin/pkg_add', '-r']) + packages]
+            return [self.elevate_priv(['/usr/sbin/pkg', 'install', '-y']) + packages]

--- a/test/test_rosdep_freebsd.py
+++ b/test/test_rosdep_freebsd.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2011, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Copied from test_rosdep_suse.py by Author Ken Conley/kwc@willowgarage.com
+# Converted to FreeBSD by Trenton Schulz/trentonw@ifi.uio.no
+
+import os
+import traceback
+from mock import patch, Mock
+
+
+def get_test_dir():
+    # not used yet
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), 'freebsd'))
+
+
+def test_pkg_detect():
+    from rosdep2.platforms.freebsd import pkg_detect
+
+    m = Mock()
+    m.return_value = ''
+
+    val = pkg_detect([], exec_fn=m)
+    assert val == [], val
+
+    val = pkg_detect(['tinyxml'], exec_fn=m)
+    assert val == [], val
+
+
+def test_PkgInstaller():
+    from rosdep2.platforms.freebsd import PkgInstaller
+
+    @patch.object(PkgInstaller, 'get_packages_to_install')
+    def test(mock_method):
+        installer = PkgInstaller()
+        mock_method.return_value = []
+        assert [] == installer.get_install_command(['fake'])
+
+        # no interactive option with YUM
+        mock_method.return_value = ['a', 'b']
+        expected = [['sudo', '-H', '/usr/sbin/pkg', 'install', '-y', 'a', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=False)
+        assert val == expected, val
+        expected = [['sudo', '-H', '/usr/sbin/pkg', 'install', '-y', 'a', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=True)
+        assert val == expected, val
+    try:
+        test()
+    except AssertionError:
+        traceback.print_exc()
+        raise


### PR DESCRIPTION
This is a re-submission of #566 that is much cleaner. I hope it can make it through this time.

The FreeBSD system is now using pkg, which is modern, binary-based,
and comparable to apt or rpm. This starts using the system, with some
very rudimentary tests.

From discussion, the REP112 is going the way of the
dinosaur. So, the FreeBSD installer no longer uses this source installer.

If anyone wants to run the whole testsuite on FreeBSD, you'll also
need to make some stub programs for apt-get to work (a simple script
that just return zero will suffice), install rpm, and link bash into
/bin (sacrilige on a FreeBSD system). Note that that's just to get rid
of false positive for tests that run on other platforms.