### PR TITLE
conflict with upstream's python-rosdep2

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,7 @@
 [DEFAULT]
 Depends: ca-certificates, python-rospkg (>= 1.0.37), python-yaml, python-catkin-pkg, python-rosdistro (>= 0.4.0)
 Depends3: ca-certificates, python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0)
-Conflicts: python3-rosdep
-Conflicts3: python-rosdep
+Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
+Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
https://github.com/ros/rosdistro/issues/16768#issuecomment-359527357 revealed that the upstream package of rosdep has been renamed to rosdep2 (in artful, bionic and buster). So we need to conflict against that package as well.