### PR TITLE
Mac support in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ matrix:
       python: 3.4
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=2.7
+      env: TRAVIS_PYTHON_VERSION=2.7.14
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=3.4.8
+      env: TRAVIS_PYTHON_VERSION=3.6.4
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,27 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.4"
+matrix:
+  include:
+    - os: linux
+      python: 2.6
+    - os: linux
+      python: 2.7
+    - os: linux
+      python: 3.4
+    - os: osx
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=2.7
+    - os: osx
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.4.8
+
 # command to install dependencies
 install:
+  - source .travis/install.sh
+  - python --version
 # develop seems to be required by travis since 02/2013
   - pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
   - python setup.py build develop
-  - pip install nose coverage flake8
+  - pip install nose coverage flake8 mock
 # command to run tests
 script:
   - nosetests --with-coverage --cover-package=rosdep2 --with-xunit test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,20 @@ matrix:
       python: 3.4
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=2.7.14
+      env: PYTHON_INSTALLER=brew
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=3.6.4
+      env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=2.7.14
+    - os: osx
+      language: generic
+      env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=3.6.4
 
 # command to install dependencies
 install:
   - source .travis/install.sh
   - python --version
-# develop seems to be required by travis since 02/2013
   - pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
-  - python setup.py build develop
+  - pip install -e .
   - pip install nose coverage flake8 mock
 # command to run tests
 script:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    # Install pyenv
+    brew install pyenv-virtualenv
+    pyenv versions
+    eval "$(pyenv init -)"
+    pyenv install $TRAVIS_PYTHON_VERSION
+    PYTHON_ENV_NAME=virtual-env-$TRAVIS_PYTHON_VERSION
+    pyenv virtualenv $TRAVIS_PYTHON_VERSION $PYTHON_ENV_NAME
+    pyenv activate $PYTHON_ENV_NAME
+fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-    # Install pyenv
     brew install pyenv-virtualenv
     pyenv versions
     eval "$(pyenv init -)"

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 
-if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-    brew install pyenv-virtualenv
-    pyenv versions
-    eval "$(pyenv init -)"
-    pyenv install $TRAVIS_PYTHON_VERSION
-    PYTHON_ENV_NAME=virtual-env-$TRAVIS_PYTHON_VERSION
-    pyenv virtualenv $TRAVIS_PYTHON_VERSION $PYTHON_ENV_NAME
-    pyenv activate $PYTHON_ENV_NAME
-fi
+do_install()
+{
+    set -e
+
+    if [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'pyenv' ]]; then
+        brew install pyenv-virtualenv
+        pyenv versions
+        eval "$(pyenv init -)"
+        pyenv install $TRAVIS_PYTHON_VERSION
+        PYTHON_ENV_NAME=virtual-env-$TRAVIS_PYTHON_VERSION
+        pyenv virtualenv $TRAVIS_PYTHON_VERSION $PYTHON_ENV_NAME
+        pyenv activate $PYTHON_ENV_NAME
+
+    elif [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'brew' ]]; then
+        # nose 1.3.7 creates /usr/local/man dir if it does not exist.
+        # The operation fails because current user does not own /usr/local.  Create the dir manually instead.
+        sudo mkdir /usr/local/man
+        sudo chown -R $(whoami) $(brew --prefix)/*
+
+        export PATH=$(pwd)/.travis/shim:$PATH
+
+        mkdir -p ~/Library/Python/2.7/lib/python/site-packages
+        echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+    fi
+}
+
+do_install

--- a/.travis/shim/pip
+++ b/.travis/shim/pip
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This wrapper allows installation to call pip and it actually be
+# the pip2 that's part of brewed Python, rather than the missing
+# system pip.
+pip2 $@
+exit $?


### PR DESCRIPTION
Enables building and running tests on macOS in Travis CI. Versions of Python on macOS: 2.7 and 3.4.8.

Major work is done in .travis.yml + a new script for installation that does work for macOS.  3 tests needed fixes - they called Linux specific commands while running tests, and it does not work well on mac; fixed with mocking function that does command call.

Python on macOS is installed with `pyenv`.  Travis osx VMs have python installed with `brew`, but a) package installation for it is far from simple b) there is no tight control over version. `pyenv` works great.

[The link to the builds in my repo](https://travis-ci.org/Nickolaim/rosdep)

*Note* This is my first pull request, so I might be missing stuff.