### PR TITLE
Eliminate Python 2.6 which is EOL and add flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.4"
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
   - pip install nose coverage flake8
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - if [ "${TRAVIS_PYTHON_VERSION}" != "2.6" ] ; then flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics; fi
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - if [ "${TRAVIS_PYTHON_VERSION}" != "2.6" ] ; then flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics; fi
 # command to run tests
 script:
   - nosetests --with-coverage --cover-package=rosdep2 --with-xunit test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
 # command to install dependencies
@@ -9,6 +8,11 @@ install:
   - pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
   - python setup.py build develop
   - pip install nose coverage flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests
 script:
   - nosetests --with-coverage --cover-package=rosdep2 --with-xunit test


### PR DESCRIPTION
* Remove Python 2.6 because it [went EOL](https://devguide.python.org/#branchstatus) five years ago.
* Add [flake8](http://flake8.pycqa.org) to find Python syntax errors and undefined names.