### PR TITLE
Add badges for build status and code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - python --version
   - pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
   - pip install -e .
-  - pip install nose coverage flake8 mock
+  - pip install nose coverage flake8 mock codecov
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - if [ "${TRAVIS_PYTHON_VERSION}" != "2.6" ] ; then flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics; fi
@@ -32,5 +32,7 @@ before_script:
 # command to run tests
 script:
   - nosetests --with-coverage --cover-package=rosdep2 --with-xunit test
+after_script:
+  - codecov
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 rosdep
 ------
-[![Build Status](https://travis-ci.org/ros-infrastructure/rosdep.svg?branch=master)](https://travis-ci.org/ros-infrastructure/rosdep)
+[![Build status](https://travis-ci.org/ros-infrastructure/rosdep.svg?branch=master)](https://travis-ci.org/ros-infrastructure/rosdep)
 [![codecov](https://codecov.io/gh/ros-infrastructure/rosdep/branch/master/graph/badge.svg)](https://codecov.io/gh/ros-infrastructure/rosdep)
 
 rosdep is a command-line tool for installing system dependencies. For *end-users*, rosdep helps you install system dependencies for software that you are building from source. For *developers*, rosdep simplifies the problem of installing system dependencies on different platforms. Instead of having to figure out which debian package on Ubuntu Oneiric contains Boost, you can just specify a dependency on 'boost'.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 rosdep
 ------
+[![Build Status](https://travis-ci.org/ros-infrastructure/rosdep.svg?branch=master)](https://travis-ci.org/ros-infrastructure/rosdep)
+[![codecov](https://codecov.io/gh/ros-infrastructure/rosdep/branch/master/graph/badge.svg)](https://codecov.io/gh/ros-infrastructure/rosdep)
 
 rosdep is a command-line tool for installing system dependencies. For *end-users*, rosdep helps you install system dependencies for software that you are building from source. For *developers*, rosdep simplifies the problem of installing system dependencies on different platforms. Instead of having to figure out which debian package on Ubuntu Oneiric contains Boost, you can just specify a dependency on 'boost'.
 


### PR DESCRIPTION
The badge for build status will start working automatically, since it takes status from Travis CI.

For the code coverage the repo owner needs to login to [https://codecov.io/gh](https://codecov.io/gh) and enable code coverage for `ros-infrastructure/rosdep`.