### PR TITLE
Remove flake from .travis.ci, since it is already running in unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,6 @@ install:
   - pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
   - pip install -e .
   - pip install nose coverage flake8 mock codecov
-before_script:
-  # stop the build if there are Python syntax errors or undefined names
-  - if [ "${TRAVIS_PYTHON_VERSION}" != "2.6" ] ; then flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics; fi
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - if [ "${TRAVIS_PYTHON_VERSION}" != "2.6" ] ; then flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics; fi
 # command to run tests
 script:
   - nosetests --with-coverage --cover-package=rosdep2 --with-xunit test

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -43,6 +43,7 @@ def test_flake8():
             'N802',  # ignore presence of upper case in function names
         ],
         max_line_length=200,
+        max_complexity=10,
         show_source=True,
     )
 


### PR DESCRIPTION
Move the only missing `max-complexity` option from .travis.yml to
the unit test. Setting max line length to 127 caused 31 errors -
not practical right now, keep at the old value of 200.
The other rules are already enabled. This is the list of rules enabled
in unit tests: ['E', 'F', 'W', 'C90'].

Fixes issue #596 