### PR TITLE
fix py2.7 flake8 error reporting bug

### DIFF
--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -64,4 +64,4 @@ def test_flake8():
             .format_map(locals()), file=sys.stderr)
 
     assert not report.total_errors, \
-        'flake8 reported {report.total_errors} errors'.format_map(locals())
+        'flake8 reported {report.total_errors} errors'.format(**locals())


### PR DESCRIPTION
format_map is 3.2+ only

I found/tested this here: https://travis-ci.org/wjwwood/parse_cmake/builds/357160260?utm_source=github_status&utm_medium=notification