### PR TITLE
Add support for downloading a python3 version of the rosdep database.

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -67,7 +67,7 @@ from .rospkg_loader import DEFAULT_VIEW_KEY
 from .sources_list import update_sources_list, get_sources_cache_dir,\
     download_default_sources_list, SourcesListLoader, CACHE_INDEX,\
     get_sources_list_dir, get_default_sources_list_file,\
-    DEFAULT_SOURCES_LIST_URL
+    get_default_sources_list_url
 from .rosdistrohelper import PreRep137Warning
 
 from .catkin_packages import find_catkin_packages_in
@@ -525,10 +525,10 @@ def command_init(options):
     try:
         data = download_default_sources_list()
     except URLError as e:
-        print('ERROR: cannot download default sources list from:\n%s\nWebsite may be down.' % (DEFAULT_SOURCES_LIST_URL))
+        print('ERROR: cannot download default sources list from:\n%s\nWebsite may be down.' % (get_default_sources_list_url()))
         return 4
     except DownloadFailure as e:
-        print('ERROR: cannot download default sources list from:\n%s\nWebsite may be down.' % (DEFAULT_SOURCES_LIST_URL))
+        print('ERROR: cannot download default sources list from:\n%s\nWebsite may be down.' % (get_default_sources_list_url()))
         print(e)
         return 4
     # reuse path variable for error message

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -66,7 +66,8 @@ from .rosdistrohelper import get_index, get_index_url
 
 # default file to download with 'init' command in order to bootstrap
 # rosdep
-DEFAULT_SOURCES_LIST_URL = 'https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list'
+DEFAULT_SOURCES_LIST_URL_PY2 = 'https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list'
+DEFAULT_SOURCES_LIST_URL_PY3 = 'https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default-py3.list'
 
 # seconds to wait before aborting download of rosdep data
 DOWNLOAD_TIMEOUT = 15.0
@@ -112,6 +113,20 @@ def get_sources_list_dir():
 
 def get_default_sources_list_file():
     return os.path.join(get_sources_list_dir(), '20-default.list')
+
+
+def get_default_sources_list_url():
+    if 'ROS_PYTHON_VERSION' in os.environ:
+        pyversion = os.environ['ROS_PYTHON_VERSION']
+    else:
+        pyversion = "2"
+
+    if pyversion == "2":
+        return DEFAULT_SOURCES_LIST_URL_PY2
+    elif pyversion == "3":
+        return DEFAULT_SOURCES_LIST_URL_PY3
+    else:
+        raise ValueError('ROS_PYTHON_VERSION must be either "2" or "3"')
 
 
 def get_sources_cache_dir():
@@ -317,7 +332,7 @@ def download_rosdep_data(url):
         raise DownloadFailure(str(e))
 
 
-def download_default_sources_list(url=DEFAULT_SOURCES_LIST_URL):
+def download_default_sources_list(url=None):
     """
     Download (and validate) contents of default sources list.
 
@@ -328,6 +343,10 @@ def download_default_sources_list(url=DEFAULT_SOURCES_LIST_URL):
     :raises: :exc:`urllib2.URLError` If data cannot be
         retrieved (e.g. 404, server down).
     """
+
+    if url is None:
+        url = get_default_sources_list_url()
+
     try:
         f = urlopen(url, timeout=DOWNLOAD_TIMEOUT)
     except (URLError, httplib.HTTPException) as e:

--- a/test/test_rosdep_sources_list.py
+++ b/test/test_rosdep_sources_list.py
@@ -64,11 +64,12 @@ def test_url_constants():
 
     # TODO: once we have the Python3 version of the default sources list
     # up on rosdistro, we can enable the test for both 2 and 3.
-    #for version in ['2', '3']:
+    # for version in ['2', '3']:
     for version in ['2']:
         os.environ['ROS_PYTHON_VERSION'] = version
+        url = get_default_sources_list_url()
         try:
-            f = urlopen(get_default_sources_list_url())
+            f = urlopen(url)
             f.read()
             f.close()
         except Exception:

--- a/test/test_rosdep_sources_list.py
+++ b/test/test_rosdep_sources_list.py
@@ -54,14 +54,41 @@ def test_get_sources_cache_dir():
 
 
 def test_url_constants():
-    from rosdep2.sources_list import DEFAULT_SOURCES_LIST_URL
-    for url_name, url in [('DEFAULT_SOURCES_LIST_URL', DEFAULT_SOURCES_LIST_URL)]:
+    from rosdep2.sources_list import get_default_sources_list_url
+
+    # We'll be playing around with the ROS_PYTHON_VERSION environment variable,
+    # so save it off here.
+    orig_env = None
+    if 'ROS_PYTHON_VERSION' in os.environ:
+        orig_env = os.environ['ROS_PYTHON_VERSION']
+
+    # TODO: once we have the Python3 version of the default sources list
+    # up on rosdistro, we can enable the test for both 2 and 3.
+    #for version in ['2', '3']:
+    for version in ['2']:
+        os.environ['ROS_PYTHON_VERSION'] = version
         try:
-            f = urlopen(url)
+            f = urlopen(get_default_sources_list_url())
             f.read()
             f.close()
         except Exception:
-            assert False, 'URL [%s][%s] failed to download' % (url_name, url)
+            assert False, 'URL [%s] failed to download' % (url)
+
+    # Try setting a bogus python version
+    os.environ['ROS_PYTHON_VERSION'] = 'foo'
+    try:
+        get_default_sources_list_url()
+        assert False, 'get_default_sources_list_url() should have failed with invalid python version'
+    except ValueError:
+        pass
+
+    # Reset the ROS_PYTHON_VERSION environment variable to its default.  If
+    # orig_env is None, it means that there was no entry for it originally
+    # so we delete it.
+    if orig_env is None:
+        del os.environ['ROS_PYTHON_VERSION']
+    else:
+        os.environ['ROS_PYTHON_VERSION'] = orig_env
 
 
 def test_download_default_sources_list():


### PR DESCRIPTION
What we do here is to add an alternate version of https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list, called https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default-py3.list .  The `20-default.list` stays the same, while the `20-default-py3.list` points to a yaml file called `python3.yaml` ([example](https://gist.github.com/clalancette/a0024772b693d712dad2bdd30b0ce0f6)).  That version of the yaml file maps rosdep keys to their python3 equivalents.  `python3.yaml` is only used if the `ROS_PYTHON_VERSION` environment variable is set to `3`, otherwise it defaults to using the standard `python.yaml` (in order to use Python 3 successfully, users must have `ROS_PYTHON_VERSION` set to `3` both during `sudo rosdep init` and during `rosdep update`).

Doing it this way has a few different benefits and drawbacks.

Benefits:
* Keeps using existing Python 2 support for the case where `ROS_PYTHON_VERSION` is not set and where it is set to `2`.
* The Python 3 keys are kept in an entirely different database so there is no confusion in the `python.yaml` file.
* To switch over to Python 3 by default in a future ROS release, we only have to change the `20-default.list` file to point to the `python3.yaml` file, and change `ROS_PYTHON_VERSION` to be `3` over in ros_environment.

Drawbacks:
* In order to switch over to the Python 3 version of the rosdep database, users must do a few things:
  * Remove `~/.ros/rosdep/sources.cache/*`
  * Remove (using sudo) `/etc/ros/rosdep/sources.list.d/20-default.list`
  * Set `ROS_PYTHON_VERSION` to `3` in their user account.
  * Set `ROS_PYTHON_VERSION` to `3` in the root account.
  * Run `sudo rosdep init`
  * Run `rosdep update`
* We are not using the `<os>_python3` keys that are already in the existing `python.yaml` file (e.g. https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L226)