### PR TITLE
Add reference to LICENSE file in stdeb.cfg

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,6 @@ Depends: ca-certificates, python-rospkg (>= 1.0.37), python-yaml, python-catkin-
 Depends3: ca-certificates, python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0)
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
+Copyright-File: LICENSE
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Add the parameter to install the license/copyright file in the debian way.
https://github.com/astraw/stdeb#stdebcfg-configuration-file