### PR TITLE
Fix CI build for osx homebrew

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -23,6 +23,9 @@ do_install()
 
         mkdir -p ~/Library/Python/2.7/lib/python/site-packages
         echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+
+        # Brew-installed numpy contains nose under numpy directory which is not in PATH.
+        pip install --upgrade --ignore-installed nose
     fi
 }
 


### PR DESCRIPTION
This commit fixes osx homebrew CI build by reinstalling nose to correct place.
Brew-installed numpy contains nose under numpy directory which is not in PATH.