### PR TITLE
Decode stdout during documentation build

### DIFF
--- a/doc/rosdep_doc_utils.py
+++ b/doc/rosdep_doc_utils.py
@@ -35,14 +35,14 @@ class RosdepCLIDirective(Directive):
                 [py, '-c', "from rosdep2.main import rosdep_main;rosdep_main(['-h'])"]
             )
             return [
-                nodes.literal_block(text=re.sub(escaped_capitalized_usage, '', out))
+                nodes.literal_block(text=re.sub(escaped_capitalized_usage, '', out.decode()))
             ]
         if 'install' in self.arguments:
             out = subprocess.check_output(
                 [py, '-c', "from rosdep2.main import rosdep_main;rosdep_main(['install', '-h'])"]
             )
             return [
-                nodes.literal_block(text=re.sub(escaped_capitalized_usage, '', out))
+                nodes.literal_block(text=re.sub(escaped_capitalized_usage, '', out.decode()))
             ]
 
 


### PR DESCRIPTION
I think that I'm seeing this because doc builds are happening with python 3 on Fedora. Looks like `subprocess.check_output` returns a byte string, which needs to be decoded for `re.sub`.

Here is the error I'm seeing:
```
  ...
  File "./rosdep_doc_utils.py", line 38, in run
    nodes.literal_block(text=re.sub(escaped_capitalized_usage, '', out))
  File "/usr/lib64/python3.6/re.py", line 191, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: cannot use a string pattern on a bytes-like object
```