### PR TITLE
format_map is python 3.2 or later only (see also #602)

### DIFF
--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -53,7 +53,7 @@ def test_flake8():
         report._application.formatter.show_statistics(report._stats)
         print(
             'flake8 reported {report.total_errors} errors'
-            .format_map(locals()), file=sys.stderr)
+            .format(**locals()), file=sys.stderr)
 
     assert not report.total_errors, \
         'flake8 reported {report.total_errors} errors'.format(**locals())


### PR DESCRIPTION
Breaks travis, e.g.: https://travis-ci.org/ros-infrastructure/rosdep/jobs/445522297