### PR TITLE
Make DNF install best-effort like YUM

### DIFF
--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -155,13 +155,13 @@ class DnfInstaller(PackageManagerInstaller):
         if not packages:
             return []
         elif not interactive and quiet:
-            return [self.elevate_priv(['dnf', '--assumeyes', '--quiet', 'install']) + packages]
+            return [self.elevate_priv(['dnf', '--assumeyes', '--quiet', '--setopt=strict=0', 'install']) + packages]
         elif quiet:
-            return [self.elevate_priv(['dnf', '--quiet', 'install']) + packages]
+            return [self.elevate_priv(['dnf', '--quiet', '--setopt=strict=0', 'install']) + packages]
         elif not interactive:
-            return [self.elevate_priv(['dnf', '--assumeyes', 'install']) + packages]
+            return [self.elevate_priv(['dnf', '--assumeyes', '--setopt=strict=0', 'install']) + packages]
         else:
-            return [self.elevate_priv(['dnf', 'install']) + packages]
+            return [self.elevate_priv(['dnf', '--setopt=strict=0', 'install']) + packages]
 
 
 class YumInstaller(PackageManagerInstaller):

--- a/test/test_rosdep_redhat.py
+++ b/test/test_rosdep_redhat.py
@@ -87,16 +87,16 @@ def test_DnfInstaller():
 
         # no interactive option with YUM
         mock_method.return_value = ['a', 'b']
-        expected = [['sudo', '-H', 'dnf', '--assumeyes', '--quiet', 'install', 'a', 'b']]
+        expected = [['sudo', '-H', 'dnf', '--assumeyes', '--quiet', '--setopt=strict=0', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False, quiet=True)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'dnf', '--quiet', 'install', 'a', 'b']]
+        expected = [['sudo', '-H', 'dnf', '--quiet', '--setopt=strict=0', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True, quiet=True)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'dnf', '--assumeyes', 'install', 'a', 'b']]
+        expected = [['sudo', '-H', 'dnf', '--assumeyes', '--setopt=strict=0', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False, quiet=False)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'dnf', 'install', 'a', 'b']]
+        expected = [['sudo', '-H', 'dnf', '--setopt=strict=0', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True, quiet=False)
         assert val == expected, val + expected
     try:


### PR DESCRIPTION
When the `DnfInstaller` was added, I believed that DNF's default behavior was best-effort, and this was the reason that the YUM option `--skip-broken` didn't work. It turns out that this is only the case for updates, and that the `install` verb still needs to be told to be best-effort.

At some point `--skip-broken` was added to DNF as an alias for `--setopt=strict=0`. Since older DNF versions don't support `--skip-broken`, we should use `--setopt=strict=0` directly to achieve the expected behavior here.

When a broken package install is attempted, DNF will return 0 and rosdep will detect the missing package as "was supposed to be installed but was not," prompting further inspection of the DNF console output.