### PR TITLE
skip EOL distros by default, add option to include them

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -329,6 +329,11 @@ def _rosdep_main(args):
                       'whether sudo is used for a specific installer, '
                       "e.g. '--as-root pip:false' or '--as-root \"pip:no homebrew:yes\"'. "
                       'Can be specified multiple times.')
+    parser.add_option('--include-eol-distros', dest='include_eol_distros',
+                      default=False, action='store_true',
+                      help="Affects the 'update' verb. "
+                           'If specified end-of-life distros are being '
+                           'fetched too.')
 
     options, args = parser.parse_args(args)
     if options.print_version or options.print_all_versions:
@@ -592,7 +597,8 @@ def command_update(options):
             # nothing we wanna do under Windows
             pass
         update_sources_list(success_handler=update_success_handler,
-                            error_handler=update_error_handler)
+                            error_handler=update_error_handler,
+                            include_eol_distros=options.include_eol_distros)
         print('updated cache in %s' % (sources_cache_dir))
     except InvalidData as e:
         print('ERROR: invalid sources list file:\n\t%s' % (e), file=sys.stderr)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -598,7 +598,7 @@ def command_update(options):
             pass
         update_sources_list(success_handler=update_success_handler,
                             error_handler=update_error_handler,
-                            include_eol_distros=options.include_eol_distros)
+                            skip_eol_distros=not options.include_eol_distros)
         print('updated cache in %s' % (sources_cache_dir))
     except InvalidData as e:
         print('ERROR: invalid sources list file:\n\t%s' % (e), file=sys.stderr)

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -439,7 +439,8 @@ def _generate_key_from_urls(urls):
 
 
 def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
-                        success_handler=None, error_handler=None):
+                        success_handler=None, error_handler=None,
+                        include_eol_distros=False):
     """
     Re-downloaded data from remote sources and store in cache.  Also
     update the cache index based on current sources.
@@ -485,11 +486,16 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
     # In compliance with REP137 and REP143
     print('Query rosdistro index %s' % get_index_url())
     for dist_name in sorted(get_index().distributions.keys()):
+        distribution = get_index().distributions[dist_name]
+        if not include_eol_distros:
+            if distribution.get('distribution_status') == 'end-of-life':
+                print('Skip end-of-life distro "%s"' % dist_name)
+                continue
         print('Add distro "%s"' % dist_name)
         rds = RosDistroSource(dist_name)
         rosdep_data = get_gbprepo_as_rosdep_data(dist_name)
         # dist_files can either be a string (single filename) or a list (list of filenames)
-        dist_files = get_index().distributions[dist_name]['distribution']
+        dist_files = distribution['distribution']
         key = _generate_key_from_urls(dist_files)
         retval.append((rds, write_cache_file(sources_cache_dir, key, rosdep_data)))
         sources.append(rds)

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -453,6 +453,7 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
     :param error_handler: fn(DataSource, DownloadFailure) to call
         if a particular source fails.  This hook is mainly for
         printing errors to console.
+    :param include_eol_distros: additionally download sources for EOL distros
 
     :returns: list of (`DataSource`, cache_file_path) pairs for cache
         files that were updated, ``[str]``

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -440,7 +440,7 @@ def _generate_key_from_urls(urls):
 
 def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
                         success_handler=None, error_handler=None,
-                        include_eol_distros=False):
+                        skip_eol_distros=False):
     """
     Re-downloaded data from remote sources and store in cache.  Also
     update the cache index based on current sources.
@@ -453,7 +453,7 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
     :param error_handler: fn(DataSource, DownloadFailure) to call
         if a particular source fails.  This hook is mainly for
         printing errors to console.
-    :param include_eol_distros: additionally download sources for EOL distros
+    :param skip_eol_distros: skip downloading sources for EOL distros
 
     :returns: list of (`DataSource`, cache_file_path) pairs for cache
         files that were updated, ``[str]``
@@ -488,7 +488,7 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
     print('Query rosdistro index %s' % get_index_url())
     for dist_name in sorted(get_index().distributions.keys()):
         distribution = get_index().distributions[dist_name]
-        if not include_eol_distros:
+        if skip_eol_distros:
             if distribution.get('distribution_status') == 'end-of-life':
                 print('Skip end-of-life distro "%s"' % dist_name)
                 continue


### PR DESCRIPTION
With the increasing number of already EOLed ROS distros the time for `rosdep update` increases with it.

Currently `groovy`, `hydro` and `jade` are EOLed ROS 1 distros. With the merge of the ROS 2 distro into the same repo `ardent` will be another EOLed one.

This patch changes the default behavior of `rosdep update` to not fetch / consider EOLed distros which will improve its performance. The new option `--include-eol-distros` can be used to continue including EOLed distros.