### PR TITLE
Fix the unit test test_get_gbprepo_as_rosdep_data

### DIFF
--- a/test/test_rosdep_gbpdistro_support.py
+++ b/test/test_rosdep_gbpdistro_support.py
@@ -52,7 +52,7 @@ def test_url_constants():
 def test_get_gbprepo_as_rosdep_data():
     from rosdep2.rosdistrohelper import get_index
     from rosdep2.gbpdistro_support import get_gbprepo_as_rosdep_data
-    distro = sorted(get_index().distributions.keys())[0]
+    distro = "melodic"
     data = get_gbprepo_as_rosdep_data(distro)
     for k in ['ros', 'catkin', 'genmsg']:
         assert k in data, data


### PR DESCRIPTION
The unit test checks for the existence of three keys `['ros', 'catkin', 'genmsg']` in the rosdep data gathered from a distro. As coded, it gets the first distribution found in alphabetical order. As of today `ardent`. However this is a ros2 distribution and, for example, catkin [is not released for it](https://github.com/ros/rosdistro/blob/master/ardent/distribution.yaml). 

I propose to use `melodic` as this is the latest ros1 distribution where those keys are guaranteed to be there. Otherwise, the keys can be change by removing "catkin" and "genmsg".