### PR TITLE
use yaml.safe_load for untrusted yaml input

### DIFF
--- a/src/rosdep2/loader.py
+++ b/src/rosdep2/loader.py
@@ -55,7 +55,7 @@ class RosdepLoader:
         :raises: :exc:`yaml.YAMLError`
         """
         try:
-            return yaml.load(yaml_contents)
+            return yaml.safe_load(yaml_contents)
         except yaml.YAMLError as e:
             raise InvalidData('Invalid YAML in [%s]: %s' % (origin, e), origin=origin)
 


### PR DESCRIPTION
The patch only updates the invocation where untrusted sources are being processed.