### PR TITLE
Filter ros2 distros out when testing ros1 rosdep data.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version=__version__,  # noqa:F821
     packages=['rosdep2', 'rosdep2.platforms'],
     package_dir={'': 'src'},
-    install_requires=['catkin_pkg', 'rospkg >= 1.0.37', 'rosdistro >= 0.4.0', 'PyYAML >= 3.1'],
+    install_requires=['catkin_pkg', 'rospkg >= 1.0.37', 'rosdistro >= 0.7.0', 'PyYAML >= 3.1'],
     test_suite='nose.collector',
     test_requires=['mock', 'nose >= 1.0'],
     scripts=['scripts/rosdep', 'scripts/rosdep-source'],

--- a/test/test_rosdep_gbpdistro_support.py
+++ b/test/test_rosdep_gbpdistro_support.py
@@ -52,7 +52,9 @@ def test_url_constants():
 def test_get_gbprepo_as_rosdep_data():
     from rosdep2.rosdistrohelper import get_index
     from rosdep2.gbpdistro_support import get_gbprepo_as_rosdep_data
-    distro = sorted(get_index().distributions.keys())[0]
+    distro = sorted(
+            d for d, info in get_index().distributions.items()
+            if info['distribution_type'] == 'ros1')[0]
     data = get_gbprepo_as_rosdep_data(distro)
     for k in ['ros', 'catkin', 'genmsg']:
         assert k in data, data

--- a/test/test_rosdep_gbpdistro_support.py
+++ b/test/test_rosdep_gbpdistro_support.py
@@ -54,7 +54,7 @@ def test_get_gbprepo_as_rosdep_data():
     from rosdep2.gbpdistro_support import get_gbprepo_as_rosdep_data
     distro = sorted(
         name for name, info in get_index().distributions.items()
-        if info['distribution_type'] == 'ros1')[0]
+        if info.get('distribution_type') == 'ros1')[0]
     data = get_gbprepo_as_rosdep_data(distro)
     for k in ['ros', 'catkin', 'genmsg']:
         assert k in data, data

--- a/test/test_rosdep_gbpdistro_support.py
+++ b/test/test_rosdep_gbpdistro_support.py
@@ -53,7 +53,7 @@ def test_get_gbprepo_as_rosdep_data():
     from rosdep2.rosdistrohelper import get_index
     from rosdep2.gbpdistro_support import get_gbprepo_as_rosdep_data
     distro = sorted(
-        d for d, info in get_index().distributions.items()
+        name for name, info in get_index().distributions.items()
         if info['distribution_type'] == 'ros1')[0]
     data = get_gbprepo_as_rosdep_data(distro)
     for k in ['ros', 'catkin', 'genmsg']:

--- a/test/test_rosdep_gbpdistro_support.py
+++ b/test/test_rosdep_gbpdistro_support.py
@@ -53,8 +53,8 @@ def test_get_gbprepo_as_rosdep_data():
     from rosdep2.rosdistrohelper import get_index
     from rosdep2.gbpdistro_support import get_gbprepo_as_rosdep_data
     distro = sorted(
-            d for d, info in get_index().distributions.items()
-            if info['distribution_type'] == 'ros1')[0]
+        d for d, info in get_index().distributions.items()
+        if info['distribution_type'] == 'ros1')[0]
     data = get_gbprepo_as_rosdep_data(distro)
     for k in ['ros', 'catkin', 'genmsg']:
         assert k in data, data


### PR DESCRIPTION
This should get CI green again. Since we need to use a property only available with index v4 we also need to require the version of rosdistro which uses it by default.