### PR TITLE
Update rosdep version required in stdeb.cfg.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: ca-certificates, python-rospkg (>= 1.0.37), python-yaml, python-catkin-pkg, python-rosdistro (>= 0.4.0)
-Depends3: ca-certificates, python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0)
+Depends: ca-certificates, python-rospkg (>= 1.0.37), python-yaml, python-catkin-pkg, python-rosdistro (>= 0.7.0)
+Depends3: ca-certificates, python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.7.0)
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE


### PR DESCRIPTION
Followup to https://github.com/ros-infrastructure/rosdep/pull/652
I forgot that this was specified both here and in the setup.py.