### PR TITLE
Only release on platforms supported by rosdistro 0.7.0.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -5,4 +5,4 @@ Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE
 Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
-X-Python3-Version: >= 3.2
+X-Python3-Version: >= 3.4

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: ca-certificates, python3-rospkg (>= 1.0.37), python3-yaml, python3-cat
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Closes a packaging regression on platforms no longer supported by
current rosdistro releases.

As of #655 (first released in 0.15.0) we're relying on a version of rosdistro which is not supported by older Ubuntu and Debian releases (ros-infrastructure/rosdistro#123). 

In addition to this change for future releases, the 0.15.0 release will be yanked from the platforms removed below to fix the regression.