### PR TITLE
Fix flake8 F632 error

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -347,7 +347,7 @@ def _rosdep_main(args):
         installer_keys = get_default_installer()[1]
         version_strings = []
         for key in installer_keys:
-            if key is 'source':
+            if key == 'source':
                 # Explicitly skip the source installer.
                 continue
             installer = installers[key]


### PR DESCRIPTION
Master branch and PR builds are failing due to the following flake8 error.

https://travis-ci.org/ros-infrastructure/rosdep/jobs/490897551#L546
```
/home/travis/build/ros-infrastructure/rosdep/src/rosdep2/main.py:350:16: F632 use ==/!= to compare str, bytes, and int literals
            if key is 'source':
               ^
flake8 reported 1 errors
```