### PR TITLE
fix REP3_TARGETS_URL

### DIFF
--- a/src/rosdep2/gbpdistro_support.py
+++ b/src/rosdep2/gbpdistro_support.py
@@ -33,7 +33,7 @@ except NameError:
     basestring = unicode = str
 
 # location of an example gbpdistro file for reference and testing
-FUERTE_GBPDISTRO_URL = 'https://raw.github.com/ros/rosdistro/' \
+FUERTE_GBPDISTRO_URL = 'https://raw.githubusercontent.com/ros/rosdistro/' \
     'master/releases/fuerte.yaml'
 
 # seconds to wait before aborting download of gbpdistro data

--- a/src/rosdep2/rep3.py
+++ b/src/rosdep2/rep3.py
@@ -36,7 +36,7 @@ from .core import DownloadFailure
 from .rosdistrohelper import PreRep137Warning
 
 # location of targets file for processing gbpdistro files
-REP3_TARGETS_URL = 'https://raw.github.com/ros/rosdistro/master/releases/targets.yaml'
+REP3_TARGETS_URL = 'https://raw.githubusercontent.com/ros/rosdistro/master/releases/targets.yaml'
 
 # seconds to wait before aborting download of gbpdistro data
 DOWNLOAD_TIMEOUT = 15.0

--- a/test/test_rosdep_sources_list.py
+++ b/test/test_rosdep_sources_list.py
@@ -38,7 +38,7 @@ except ImportError:
 import rospkg.distro
 import rosdep2.sources_list
 
-GITHUB_BASE_URL = 'https://raw.github.com/ros/rosdistro/master/rosdep/base.yaml'
+GITHUB_BASE_URL = 'https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml'
 
 
 def get_test_dir():
@@ -324,7 +324,7 @@ def test_download_rosdep_data():
 BADHOSTNAME_URL = 'https://badhostname.willowgarage.com/rosdep.yaml'
 GITHUB_URL = 'https://github.com/ros/rosdistro/raw/master/rosdep/base.yaml'
 GITHUB_PYTHON_URL = 'https://github.com/ros/rosdistro/raw/master/rosdep/python.yaml'
-GITHUB_FUERTE_URL = 'https://raw.github.com/ros-infrastructure/rosdep_rules/master/rosdep_fuerte.yaml'
+GITHUB_FUERTE_URL = 'https://raw.githubusercontent.com/ros-infrastructure/rosdep_rules/master/rosdep_fuerte.yaml'
 EXAMPLE_SOURCES_DATA_BAD_TYPE = 'YAML %s' % (GITHUB_URL)
 EXAMPLE_SOURCES_DATA_BAD_URL = 'yaml not-a-url tag1 tag2'
 EXAMPLE_SOURCES_DATA_BAD_LEN = 'yaml'


### PR DESCRIPTION
Not sure if this is a temporary problem, but the old URL cannot be reached anymore:
> Error 503 Backend unavailable, connection timeout
> Backend unavailable, connection timeout
