### PR TITLE
Use only major version part of RHEL version number

### DIFF
--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -68,6 +68,7 @@ def register_rhel(context):
     context.add_os_installer_key(OS_RHEL, YUM_INSTALLER)
     context.add_os_installer_key(OS_RHEL, SOURCE_INSTALLER)
     context.set_default_os_installer_key(OS_RHEL, lambda self: YUM_INSTALLER)
+    context.set_os_version_type(OS_RHEL, lambda self: self.get_version().split('.', 1)[0])
 
 
 def rpm_detect_py(packages):


### PR DESCRIPTION
At present, we don't have any rosdep rules split by release, so I don't believe this will change behavior for anyone.

We may need to differentiate between RHEL 7 and 8 because the Python 3 package names will likely change (from `python36-` to `python3-`). It would be pretty cumbersome to create rules for all of the minor versions of each RHEL release, so I'm proposing that we make rules based only on the major version.

For at least RHEL 6 and 7, the EPEL repository isn't broken up by minor release at all, so for packages sourced from there, the rule couldn't possibly differ anyway.

FYI @richmattes