### PR TITLE
Alias CentOS as RHEL

### DIFF
--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -49,9 +49,11 @@ def register_installers(context):
 
 def register_platforms(context):
     register_debian(context)
-    register_linaro(context)
     register_ubuntu(context)
+
+    # Aliases
     register_elementary(context)
+    register_linaro(context)
 
 
 def register_debian(context):

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -27,9 +27,11 @@
 
 # Author Tully Foote/tfoote@willowgarage.com
 
+from __future__ import print_function
 import subprocess
+import sys
 
-from rospkg.os_detect import OS_RHEL, OS_FEDORA
+from rospkg.os_detect import OS_CENTOS, OS_RHEL, OS_FEDORA
 
 from .pip import PIP_INSTALLER
 from .source import SOURCE_INSTALLER
@@ -53,6 +55,9 @@ def register_platforms(context):
     register_fedora(context)
     register_rhel(context)
 
+    # Aliases
+    register_centos(context)
+
 
 def register_fedora(context):
     context.add_os_installer_key(OS_FEDORA, PIP_INSTALLER)
@@ -68,6 +73,16 @@ def register_rhel(context):
     context.add_os_installer_key(OS_RHEL, YUM_INSTALLER)
     context.add_os_installer_key(OS_RHEL, SOURCE_INSTALLER)
     context.set_default_os_installer_key(OS_RHEL, lambda self: YUM_INSTALLER)
+
+
+def register_centos(context):
+    # CentOS is an alias for RHEL. If CentOS is detected and it's not set as
+    # an override force RHEL.
+    (os_name, os_version) = context.get_os_name_and_version()
+    if os_name == OS_CENTOS and not context.os_override:
+        print('rosdep detected OS: [%s] aliasing it to: [%s]' %
+              (OS_CENTOS, OS_RHEL), file=sys.stderr)
+        context.set_os_override(OS_RHEL, os_version.split('.', 1)[0])
 
 
 def rpm_detect_py(packages):


### PR DESCRIPTION
Following the same approach as was used to handle Linaro and Elementry.

Also move all platform alias registration after the regular platform registrations. These aliases call `get_os_name_and_version`, which behaves differently if the calling platform is registered.

Related to #667
Closes #366