### PR TITLE
Clarify what rosdep install does

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -87,7 +87,7 @@ rosdep check <stacks-and-packages>...
   check if the dependencies of package(s) have been met.
 
 rosdep install <stacks-and-packages>...
-  generate a bash script and then execute it.
+  download and install the dependencies of a given package or packages.
 
 rosdep db
   generate the dependency database and print it to the console.


### PR DESCRIPTION
This changes the help text of the `rosdep install` command.

I have not run rosdep with this change locally. I'm assuming it is safe because it is only changing a line in a multi-line string.