### PR TITLE
Initial OpenEmbedded support for rosdep

### DIFF
--- a/doc/rosdep_yaml_format.rst
+++ b/doc/rosdep_yaml_format.rst
@@ -38,7 +38,7 @@ rosdep supports both a *simple* and *versioned* syntax.
 The names above resolve as follows:
 
  * ``ROSDEP_NAME`` is the name referred to by manifest files. Examples: ``log4cxx`` or ``gtest``.
- * ``OS_NAME`` is the name of an OS.  Examples: ``ubuntu``, ``osx``, ``fedora``, ``debian``, or ``windows``.  
+ * ``OS_NAME`` is the name of an OS.  Examples: ``ubuntu``, ``osx``, ``fedora``, ``debian``, ``openembedded``, or ``windows``.
  * ``OS_VERSION`` (*optional*) is the name of specific versions in the OS. Examples: ``lucid`` or ``squeeze``. If no ``OS_VERSION`` is specified, the rule is assumed to apply to all versions.
  * ``PACKAGE_MANAGER`` (*optional in ROS Electric, required in ROS Fuerte*) is a key to select which package manager to use for this rosdep.  Examples: ``apt``, ``pip``, ``macports``.  
  * ``PACKAGE_ARGUMENT`` is free-form YAML that is be passed to the handler for the specified ``PACKAGE_MANAGER``.
@@ -99,6 +99,10 @@ OS name identifiers and supported package managers
 
    * ``portage`` (default)
    * ``source``
+
+ * ``openembedded`` : OpenEmbedded
+
+   * TODO: define a remote installation method for cross compiled packages
 
  * ``osx`` : Apple OS X
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version=__version__,  # noqa:F821
     packages=['rosdep2', 'rosdep2.platforms'],
     package_dir={'': 'src'},
-    install_requires=['catkin_pkg >= 0.4.0', 'rospkg >= 1.0.37', 'rosdistro >= 0.7.0', 'PyYAML >= 3.1'],
+    install_requires=['catkin_pkg >= 0.4.0', 'rospkg >= 1.1.8', 'rosdistro >= 0.7.0', 'PyYAML >= 3.1'],
     test_suite='nose.collector',
     test_requires=['mock', 'nose >= 1.0'],
     scripts=['scripts/rosdep', 'scripts/rosdep-source'],

--- a/src/rosdep2/__init__.py
+++ b/src/rosdep2/__init__.py
@@ -58,6 +58,7 @@ def create_default_installer_context(verbose=False):
     from .platforms import arch
     from .platforms import cygwin
     from .platforms import debian
+    from .platforms import openembedded
     from .platforms import gentoo
     from .platforms import opensuse
     from .platforms import osx
@@ -68,7 +69,7 @@ def create_default_installer_context(verbose=False):
     from .platforms import slackware
     from .platforms import source
 
-    platform_mods = [arch, cygwin, debian, gentoo, opensuse, osx, redhat, slackware, freebsd]
+    platform_mods = [arch, cygwin, debian, gentoo, openembedded, opensuse, osx, redhat, slackware, freebsd]
     installer_mods = [source, pip, gem] + platform_mods
 
     context = InstallerContext()

--- a/src/rosdep2/platforms/openembedded.py
+++ b/src/rosdep2/platforms/openembedded.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2019, LG Electronics, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Author Andre Rosa/andre.rosa@lge.com
+
+import subprocess
+from rospkg.os_detect import OS_OPENEMBEDDED, OsDetect
+from ..installers import PackageManagerInstaller
+OPKG_INSTALLER = 'opkg'
+
+
+def register_installers(context):
+    context.set_installer(OPKG_INSTALLER, OpkgInstaller())
+
+
+def register_platforms(context):
+    register_oe(context)
+
+
+def register_oe(context):
+    context.add_os_installer_key(OS_OPENEMBEDDED, OPKG_INSTALLER)
+    context.set_default_os_installer_key(OS_OPENEMBEDDED, lambda self: OPKG_INSTALLER)
+    context.set_os_version_type(OS_OPENEMBEDDED, OsDetect.get_codename)
+
+
+def opkg_detect(pkgs, exec_fn=None):
+    """
+    Given a list of package, return the list of installed packages.
+    NOTE: These are stubs currently and will be filled after semantics are fully defined.
+
+    :param pkgs: list of package names, optionally followed by a fixed version (`foo=3.0`)
+    :param exec_fn: function to execute Popen and read stdout (for testing)
+    :return: list elements in *pkgs* that were found installed on the system
+    """
+    raise NotImplementedError("opkg_detect is not implemented yet")
+
+
+class OpkgInstaller(PackageManagerInstaller):
+    """
+    An implementation of the Installer for use on oe systems.
+    NOTE: These are stubs currently and will be filled after semantics are fully defined.
+    """
+
+    def __init__(self):
+        super(OpkgInstaller, self).__init__(opkg_detect)
+
+    def get_version_strings(self):
+        output = subprocess.check_output(['opkg', '--version'])
+        version = output.splitlines()[0].split(' ')[2]
+        return [('opkg {}').format(version)]
+
+    def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
+        raise NotImplementedError('get_install_command is not implemented yet')

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends: ca-certificates, python-rospkg (>= 1.1.8), python-yaml, python-catkin-pkg (>= 0.4.0), python-rosdistro (>= 0.7.0)
-Depends3: ca-certificates, python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.7.0)
+Depends3: ca-certificates, python3-rospkg (>= 1.1.8), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.7.0)
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-Depends: ca-certificates, python-rospkg (>= 1.0.37), python-yaml, python-catkin-pkg (>= 0.4.0), python-rosdistro (>= 0.7.0)
+Depends: ca-certificates, python-rospkg (>= 1.1.8), python-yaml, python-catkin-pkg (>= 0.4.0), python-rosdistro (>= 0.7.0)
 Depends3: ca-certificates, python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.7.0)
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2


### PR DESCRIPTION
  * Requires related changes in rospkg and rosdistro
    https://github.com/ros-infrastructure/rospkg/pull/166
    https://github.com/ros/rosdistro/pull/20763
  * Let us map the generic system dependency name into a recipe name
    available from OE layer index at http://layers.openembedded.org
  * Mapping is based on PACKAGE_ARGUMENT free form format of
    _package_ @ _meta-layer_ , where _package_ resides in the OE _meta-layer_
  * Please see the proposal below:
    https://discourse.ros.org/t/a-proposal-for-a-superflore-oe-recipe-generation-scheme/8401