### PR TITLE
fix: make src install less verbose

### DIFF
--- a/src/rosdep2/platforms/source.py
+++ b/src/rosdep2/platforms/source.py
@@ -118,7 +118,7 @@ def load_rdmanifest(contents):
     :raises: :exc:`InvalidRdmanifest`
     """
     try:
-        return yaml.load(contents)
+        return yaml.safe_load(contents)
     except yaml.scanner.ScannerError as ex:
         raise InvalidRdmanifest('Failed to parse yaml in %s:  Error: %s' % (contents, ex))
 

--- a/src/rosdep2/shell_utils.py
+++ b/src/rosdep2/shell_utils.py
@@ -87,7 +87,7 @@ def create_tempfile_from_string_and_execute(string_script, path=None, exec_fn=No
         fh = tempfile.NamedTemporaryFile('w', delete=False)
         fh.write(string_script)
         fh.close()
-        print('Executing script below with cwd=%s\n{{{\n%s\n}}}\n' % (path, string_script))
+        rd_debug('Executing script below with cwd=%s\n{{{\n%s\n}}}\n' % (path, string_script))
         try:
             os.chmod(fh.name, stat.S_IRWXU)
             if exec_fn is None:

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -203,7 +203,7 @@ def cache_data_source_loader(sources_cache_dir, verbose=False):
             if verbose:
                 print('loading cached data source:\n\t%s\n\t%s' % (uri, filepath), file=sys.stderr)
             with open(filepath) as f:
-                rosdep_data = yaml.load(f.read())
+                rosdep_data = yaml.safe_load(f.read())
         else:
             rosdep_data = {}
         return CachedDataSource(type_, uri, tags, rosdep_data, origin=filepath)


### PR DESCRIPTION
I have some custom .rdmanifest which install from source. Now the script is always printed in terminal (even with rosdep -q)
I think, this should be debug information. 