### PR TITLE
Add dependency to sudo

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: ca-certificates, python-rospkg (>= 1.1.8), python-yaml, python-catkin-pkg (>= 0.4.0), python-rosdistro (>= 0.7.0)
-Depends3: ca-certificates, python3-rospkg (>= 1.1.8), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.7.0)
+Depends: ca-certificates, python-rospkg (>= 1.1.8), python-yaml, python-catkin-pkg (>= 0.4.0), python-rosdistro (>= 0.7.0), sudo
+Depends3: ca-certificates, python3-rospkg (>= 1.1.8), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.7.0), sudo
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE


### PR DESCRIPTION
Having sudo installed is mandatory to run rosdep properly.