### PR TITLE
keys: add support for --ignore-src

### DIFF
--- a/test/test_rosdep_main.py
+++ b/test/test_rosdep_main.py
@@ -256,6 +256,10 @@ class TestRosdepMain(unittest.TestCase):
                 rosdep_main(['keys', 'rospack_fake', '--os', 'ubuntu:lucid', '--verbose'] + cmd_extras)
                 stdout, stderr = b
                 assert stdout.getvalue().strip() == 'testtinyxml', stdout.getvalue()
+            with fakeout() as b:
+                rosdep_main(['keys', 'another_catkin_package'] + cmd_extras + ['-i'])
+                stdout, stderr = b
+                assert stdout.getvalue().strip() == 'catkin', stdout.getvalue()
         except SystemExit:
             assert False, 'system exit occurred'
         try:


### PR DESCRIPTION
Currently `--ignore-src` is only supported by the `check` and `install` verbs. This PR resolves #685 by adding support in the `keys` verb as well, displaying dependencies that are not already satisfied by other packages in the workspace.