### PR TITLE
use `pip install --user` when `--as_root pip:false`, rather than `pip install`

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,6 @@
+installer-options:
+  pip:
+    additional-flags: user
+    sudo: false
+    command-options: --user
+

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     test_suite='nose.collector',
     test_requires=['mock', 'nose >= 1.0'],
     scripts=['scripts/rosdep', 'scripts/rosdep-source'],
+    data_files=[('etc/ros/rosdep', ['config/config.yaml'])],
     author='Tully Foote, Ken Conley',
     author_email='tfoote@osrfoundation.org',
     url='http://wiki.ros.org/rosdep',

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -326,6 +326,7 @@ class PackageManagerInstaller(Installer):
         self.supports_depends = supports_depends
         self.as_root = True
         self.sudo_command = 'sudo -H' if os.geteuid() != 0 else ''
+        self.installer_options = {}
 
     def elevate_priv(self, cmd):
         """

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -267,73 +267,73 @@ def _rosdep_main(args):
 
     parser = ArgumentParser(usage=_usage)
     parser.add_argument('--os', dest='os_override', default=None,
-                      metavar='OS_NAME:OS_VERSION', help='Override OS name and version (colon-separated), e.g. ubuntu:lucid')
+                        metavar='OS_NAME:OS_VERSION', help='Override OS name and version (colon-separated), e.g. ubuntu:lucid')
     parser.add_argument('-c', '--sources-cache-dir', dest='sources_cache_dir', default=default_sources_cache,
-                      metavar='SOURCES_CACHE_DIR', help='Override %s' % (default_sources_cache))
+                        metavar='SOURCES_CACHE_DIR', help='Override %s' % (default_sources_cache))
     parser.add_argument('--verbose', '-v', dest='verbose', default=False,
-                      action='store_true', help='verbose display')
+                        action='store_true', help='verbose display')
     parser.add_argument('--version', dest='print_version', default=False,
-                      action='store_true', help='print just the rosdep version, then exit')
+                        action='store_true', help='print just the rosdep version, then exit')
     parser.add_argument('--all-versions', dest='print_all_versions', default=False,
-                      action='store_true', help='print rosdep version and version of installers, then exit')
+                        action='store_true', help='print rosdep version and version of installers, then exit')
     parser.add_argument('--reinstall', dest='reinstall', default=False,
-                      action='store_true', help='(re)install all dependencies, even if already installed')
+                        action='store_true', help='(re)install all dependencies, even if already installed')
     parser.add_argument('--default-yes', '-y', dest='default_yes', default=False,
-                      action='store_true', help='Tell the package manager to default to y or fail when installing')
+                        action='store_true', help='Tell the package manager to default to y or fail when installing')
     parser.add_argument('--simulate', '-s', dest='simulate', default=False,
-                      action='store_true', help='Simulate install')
+                        action='store_true', help='Simulate install')
     parser.add_argument('-r', dest='robust', default=False,
-                      action='store_true', help='Continue installing despite errors.')
+                        action='store_true', help='Continue installing despite errors.')
     parser.add_argument('-q', dest='quiet', default=False,
-                      action='store_true', help='Quiet. Suppress output except for errors.')
+                        action='store_true', help='Quiet. Suppress output except for errors.')
     parser.add_argument('-a', '--all', dest='rosdep_all', default=False,
-                      action='store_true', help='select all packages')
+                        action='store_true', help='select all packages')
     parser.add_argument('-n', dest='recursive', default=True,
-                      action='store_false', help="Do not consider implicit/recursive dependencies.  Only valid with 'keys', 'check', and 'install' commands.")
+                        action='store_false', help="Do not consider implicit/recursive dependencies.  Only valid with 'keys', 'check', and 'install' commands.")
     parser.add_argument('--ignore-packages-from-source', '--ignore-src', '-i',
-                      dest='ignore_src', default=False, action='store_true',
-                      help="Affects the 'check', 'install', and 'keys' verbs. "
-                           'If specified then rosdep will ignore keys that '
-                           'are found to be catkin packages anywhere in the '
-                           'ROS_PACKAGE_PATH or in any of the directories '
-                           'given by the --from-paths option.')
+                        dest='ignore_src', default=False, action='store_true',
+                        help="Affects the 'check', 'install', and 'keys' verbs. "
+                        'If specified then rosdep will ignore keys that '
+                        'are found to be catkin packages anywhere in the '
+                        'ROS_PACKAGE_PATH or in any of the directories '
+                        'given by the --from-paths option.')
     parser.add_argument('--skip-keys',
-                      dest='skip_keys', action='append', default=[],
-                      help="Affects the 'check' and 'install' verbs. The "
-                           'specified rosdep keys will be ignored, i.e. not '
-                           'resolved and not installed. The option can be supplied multiple '
-                           'times. A space separated list of rosdep keys can also '
-                           'be passed as a string. A more permanent solution to '
-                           'locally ignore a rosdep key is creating a local rosdep rule '
-                           'with an empty list of packages (include it in '
-                           '/etc/ros/rosdep/sources.list.d/ before the defaults).')
+                        dest='skip_keys', action='append', default=[],
+                        help="Affects the 'check' and 'install' verbs. The "
+                        'specified rosdep keys will be ignored, i.e. not '
+                        'resolved and not installed. The option can be supplied multiple '
+                        'times. A space separated list of rosdep keys can also '
+                        'be passed as a string. A more permanent solution to '
+                        'locally ignore a rosdep key is creating a local rosdep rule '
+                        'with an empty list of packages (include it in '
+                        '/etc/ros/rosdep/sources.list.d/ before the defaults).')
     parser.add_argument('--filter-for-installers',
-                      action='append', default=[],
-                      help="Affects the 'db' verb. If supplied, the output of the 'db' "
-                           'command is filtered to only list packages whose installer '
-                           'is in the provided list. The option can be supplied '
-                           'multiple times. A space separated list of installers can also '
-                           'be passed as a string. Example: `--filter-for-installers "apt pip"`')
+                        action='append', default=[],
+                        help="Affects the 'db' verb. If supplied, the output of the 'db' "
+                        'command is filtered to only list packages whose installer '
+                        'is in the provided list. The option can be supplied '
+                        'multiple times. A space separated list of installers can also '
+                        'be passed as a string. Example: `--filter-for-installers "apt pip"`')
     parser.add_argument('--from-paths', dest='from_paths',
-                      default=False, action='store_true',
-                      help="Affects the 'check', 'keys', and 'install' verbs. "
-                           'If specified the arguments to those verbs will be '
-                           'considered paths to be searched, acting on all '
-                           'catkin packages found there in.')
+                        default=False, action='store_true',
+                        help="Affects the 'check', 'keys', and 'install' verbs. "
+                        'If specified the arguments to those verbs will be '
+                        'considered paths to be searched, acting on all '
+                        'catkin packages found there in.')
     parser.add_argument('--rosdistro', dest='ros_distro', default=None,
-                      help='Explicitly sets the ROS distro to use, overriding '
-                           'the normal method of detecting the ROS distro '
-                           'using the ROS_DISTRO environment variable.')
+                        help='Explicitly sets the ROS distro to use, overriding '
+                        'the normal method of detecting the ROS distro '
+                        'using the ROS_DISTRO environment variable.')
     parser.add_argument('--as-root', default=[], action='append',
-                      metavar='INSTALLER_KEY:<bool>', help='Override '
-                      'whether sudo is used for a specific installer, '
-                      "e.g. '--as-root pip:false' or '--as-root \"pip:no homebrew:yes\"'. "
-                      'Can be specified multiple times.')
+                        metavar='INSTALLER_KEY:<bool>', help='Override '
+                        'whether sudo is used for a specific installer, '
+                        "e.g. '--as-root pip:false' or '--as-root \"pip:no homebrew:yes\"'. "
+                        'Can be specified multiple times.')
     parser.add_argument('--include-eol-distros', dest='include_eol_distros',
-                      default=False, action='store_true',
-                      help="Affects the 'update' verb. "
-                           'If specified end-of-life distros are being '
-                           'fetched too.')
+                        default=False, action='store_true',
+                        help="Affects the 'update' verb. "
+                        'If specified end-of-life distros are being '
+                        'fetched too.')
 
     options, args = parser.parse_known_args(args)
     if options.print_version or options.print_all_versions:

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -52,7 +52,7 @@ except ImportError:
     from urllib2 import URLError
 import warnings
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 import rospkg
 
@@ -265,39 +265,39 @@ def _rosdep_main(args):
     # sources cache dir is our local database.
     default_sources_cache = get_sources_cache_dir()
 
-    parser = OptionParser(usage=_usage, prog='rosdep')
-    parser.add_option('--os', dest='os_override', default=None,
+    parser = ArgumentParser(usage=_usage)
+    parser.add_argument('--os', dest='os_override', default=None,
                       metavar='OS_NAME:OS_VERSION', help='Override OS name and version (colon-separated), e.g. ubuntu:lucid')
-    parser.add_option('-c', '--sources-cache-dir', dest='sources_cache_dir', default=default_sources_cache,
+    parser.add_argument('-c', '--sources-cache-dir', dest='sources_cache_dir', default=default_sources_cache,
                       metavar='SOURCES_CACHE_DIR', help='Override %s' % (default_sources_cache))
-    parser.add_option('--verbose', '-v', dest='verbose', default=False,
+    parser.add_argument('--verbose', '-v', dest='verbose', default=False,
                       action='store_true', help='verbose display')
-    parser.add_option('--version', dest='print_version', default=False,
+    parser.add_argument('--version', dest='print_version', default=False,
                       action='store_true', help='print just the rosdep version, then exit')
-    parser.add_option('--all-versions', dest='print_all_versions', default=False,
+    parser.add_argument('--all-versions', dest='print_all_versions', default=False,
                       action='store_true', help='print rosdep version and version of installers, then exit')
-    parser.add_option('--reinstall', dest='reinstall', default=False,
+    parser.add_argument('--reinstall', dest='reinstall', default=False,
                       action='store_true', help='(re)install all dependencies, even if already installed')
-    parser.add_option('--default-yes', '-y', dest='default_yes', default=False,
+    parser.add_argument('--default-yes', '-y', dest='default_yes', default=False,
                       action='store_true', help='Tell the package manager to default to y or fail when installing')
-    parser.add_option('--simulate', '-s', dest='simulate', default=False,
+    parser.add_argument('--simulate', '-s', dest='simulate', default=False,
                       action='store_true', help='Simulate install')
-    parser.add_option('-r', dest='robust', default=False,
+    parser.add_argument('-r', dest='robust', default=False,
                       action='store_true', help='Continue installing despite errors.')
-    parser.add_option('-q', dest='quiet', default=False,
+    parser.add_argument('-q', dest='quiet', default=False,
                       action='store_true', help='Quiet. Suppress output except for errors.')
-    parser.add_option('-a', '--all', dest='rosdep_all', default=False,
+    parser.add_argument('-a', '--all', dest='rosdep_all', default=False,
                       action='store_true', help='select all packages')
-    parser.add_option('-n', dest='recursive', default=True,
+    parser.add_argument('-n', dest='recursive', default=True,
                       action='store_false', help="Do not consider implicit/recursive dependencies.  Only valid with 'keys', 'check', and 'install' commands.")
-    parser.add_option('--ignore-packages-from-source', '--ignore-src', '-i',
+    parser.add_argument('--ignore-packages-from-source', '--ignore-src', '-i',
                       dest='ignore_src', default=False, action='store_true',
                       help="Affects the 'check', 'install', and 'keys' verbs. "
                            'If specified then rosdep will ignore keys that '
                            'are found to be catkin packages anywhere in the '
                            'ROS_PACKAGE_PATH or in any of the directories '
                            'given by the --from-paths option.')
-    parser.add_option('--skip-keys',
+    parser.add_argument('--skip-keys',
                       dest='skip_keys', action='append', default=[],
                       help="Affects the 'check' and 'install' verbs. The "
                            'specified rosdep keys will be ignored, i.e. not '
@@ -307,35 +307,35 @@ def _rosdep_main(args):
                            'locally ignore a rosdep key is creating a local rosdep rule '
                            'with an empty list of packages (include it in '
                            '/etc/ros/rosdep/sources.list.d/ before the defaults).')
-    parser.add_option('--filter-for-installers',
+    parser.add_argument('--filter-for-installers',
                       action='append', default=[],
                       help="Affects the 'db' verb. If supplied, the output of the 'db' "
                            'command is filtered to only list packages whose installer '
                            'is in the provided list. The option can be supplied '
                            'multiple times. A space separated list of installers can also '
                            'be passed as a string. Example: `--filter-for-installers "apt pip"`')
-    parser.add_option('--from-paths', dest='from_paths',
+    parser.add_argument('--from-paths', dest='from_paths',
                       default=False, action='store_true',
                       help="Affects the 'check', 'keys', and 'install' verbs. "
                            'If specified the arguments to those verbs will be '
                            'considered paths to be searched, acting on all '
                            'catkin packages found there in.')
-    parser.add_option('--rosdistro', dest='ros_distro', default=None,
+    parser.add_argument('--rosdistro', dest='ros_distro', default=None,
                       help='Explicitly sets the ROS distro to use, overriding '
                            'the normal method of detecting the ROS distro '
                            'using the ROS_DISTRO environment variable.')
-    parser.add_option('--as-root', default=[], action='append',
+    parser.add_argument('--as-root', default=[], action='append',
                       metavar='INSTALLER_KEY:<bool>', help='Override '
                       'whether sudo is used for a specific installer, '
                       "e.g. '--as-root pip:false' or '--as-root \"pip:no homebrew:yes\"'. "
                       'Can be specified multiple times.')
-    parser.add_option('--include-eol-distros', dest='include_eol_distros',
+    parser.add_argument('--include-eol-distros', dest='include_eol_distros',
                       default=False, action='store_true',
                       help="Affects the 'update' verb. "
                            'If specified end-of-life distros are being '
                            'fetched too.')
 
-    options, args = parser.parse_args(args)
+    options, args = parser.parse_known_args(args)
     if options.print_version or options.print_all_versions:
         # First print the rosdep version.
         print('{}'.format(__version__))

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -115,10 +115,11 @@ class PipInstaller(PackageManagerInstaller):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)
         if not packages:
             return []
-        if self.as_root:
-            cmd = ['pip', 'install', '-U']
-        else:
-            cmd = ['pip', 'install', '-U', '--user']
+        cmd = ['pip', 'install', '-U']
+        if 'sudo' in self.installer_options:
+            self.as_root = self.installer_options['sudo']
+        if 'command-options' in self.installer_options:
+            cmd += self.installer_options['command-options'].split(' ')
         if quiet:
             cmd.append('-q')
         if reinstall:

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -115,7 +115,10 @@ class PipInstaller(PackageManagerInstaller):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)
         if not packages:
             return []
-        cmd = ['pip', 'install', '-U']
+        if self.as_root:
+            cmd = ['pip', 'install', '-U']
+        else:
+            cmd = ['pip', 'install', '-U', '--user']
         if quiet:
             cmd.append('-q')
         if reinstall:

--- a/test/ros_home/rosdep/config.yaml
+++ b/test/ros_home/rosdep/config.yaml
@@ -1,0 +1,6 @@
+installer-options:
+  pip:
+    additional-flags: user
+    sudo: false
+    command-options: --user
+

--- a/test/test_rosdep_main.py
+++ b/test/test_rosdep_main.py
@@ -68,6 +68,12 @@ def get_cache_dir():
     return p
 
 
+def get_home_dir():
+    p = os.path.join(get_test_dir(), 'ros_home')
+    assert os.path.isdir(p)
+    return p
+
+
 @contextmanager
 def fakeout():
     realstdout = sys.stdout
@@ -291,3 +297,13 @@ class TestRosdepMain(unittest.TestCase):
             assert len(output) == 2
             assert test_package_dir in output[0]
             assert 'Package version ":{version}" does not follow version conventions' in output[1]
+
+    def test_installer_options(self):
+        import rospkg
+        rospkg.get_ros_home = get_home_dir
+        sources_cache = get_cache_dir()
+        cmd_extras = ['-c', sources_cache]
+        with fakeout() as b:
+            rosdep_main(['install', 'python_dep', '--user'] + cmd_extras)
+            stdout, stderr = b
+            assert 'All required rosdeps installed' in stdout.getvalue(), stdout.getvalue()

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -103,12 +103,24 @@ def test_PipInstaller():
 
         # check as_root option with PIP
         installer.as_root = False
-        expected = [['pip', 'install', '-U', '--user', 'a'],
-                    ['pip', 'install', '-U', '--user', 'b']]
+        expected = [['pip', 'install', '-U', 'a'],
+                    ['pip', 'install', '-U', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False)
         assert val == expected, val
-        expected = [['pip', 'install', '-U', '--user', 'a'],
-                    ['pip', 'install', '-U', '--user', 'b']]
+        expected = [['pip', 'install', '-U', 'a'],
+                    ['pip', 'install', '-U', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=True)
+        assert val == expected, val
+
+        # check as_root option with PIP
+        installer = PipInstaller()
+        installer.installer_options = {'sudo': False, 'command-options': '--user -v'}
+        expected = [['pip', 'install', '-U', '--user', '-v', 'a'],
+                    ['pip', 'install', '-U', '--user', '-v', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=False)
+        assert val == expected, val
+        expected = [['pip', 'install', '-U', '--user', '-v', 'a'],
+                    ['pip', 'install', '-U', '--user', '-v', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -100,6 +100,17 @@ def test_PipInstaller():
                     ['sudo', '-H', 'pip', 'install', '-U', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
+
+        # check as_root option with PIP
+        installer.as_root = False
+        expected = [['pip', 'install', '-U', '--user', 'a'],
+                    ['pip', 'install', '-U', '--user', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=False)
+        assert val == expected, val
+        expected = [['pip', 'install', '-U', '--user', 'a'],
+                    ['pip', 'install', '-U', '--user', 'b']]
+        val = installer.get_install_command(['whatever'], interactive=True)
+        assert val == expected, val
     try:
         test()
     except AssertionError:


### PR DESCRIPTION
Current implementation runs `pip install` command when `--as-root pip:false` is set.
In most cases, it does not work because it try to install the pip package under `/usr/local` without `sudo` command
So when we set `--as-root`, I think we should use `pip install --user` command.