### PR TITLE
Add support for Nix/NixOS

### DIFF
--- a/src/rosdep2/__init__.py
+++ b/src/rosdep2/__init__.py
@@ -59,8 +59,9 @@ def create_default_installer_context(verbose=False):
     from .platforms import arch
     from .platforms import cygwin
     from .platforms import debian
-    from .platforms import openembedded
     from .platforms import gentoo
+    from .platforms import nix
+    from .platforms import openembedded
     from .platforms import opensuse
     from .platforms import osx
     from .platforms import pip
@@ -70,7 +71,7 @@ def create_default_installer_context(verbose=False):
     from .platforms import slackware
     from .platforms import source
 
-    platform_mods = [alpine, arch, cygwin, debian, gentoo, openembedded, opensuse, osx, redhat, slackware, freebsd]
+    platform_mods = [alpine, arch, cygwin, debian, gentoo, nix, openembedded, opensuse, osx, redhat, slackware, freebsd]
     installer_mods = [source, pip, gem] + platform_mods
 
     context = InstallerContext()

--- a/src/rosdep2/platforms/arch.py
+++ b/src/rosdep2/platforms/arch.py
@@ -29,10 +29,11 @@
 
 import subprocess
 
+from rospkg.os_detect import OS_ARCH
+
 from ..installers import PackageManagerInstaller
 from .source import SOURCE_INSTALLER
 
-ARCH_OS_NAME = 'arch'
 PACMAN_INSTALLER = 'pacman'
 
 
@@ -41,9 +42,9 @@ def register_installers(context):
 
 
 def register_platforms(context):
-    context.add_os_installer_key(ARCH_OS_NAME, SOURCE_INSTALLER)
-    context.add_os_installer_key(ARCH_OS_NAME, PACMAN_INSTALLER)
-    context.set_default_os_installer_key(ARCH_OS_NAME, lambda self: PACMAN_INSTALLER)
+    context.add_os_installer_key(OS_ARCH, SOURCE_INSTALLER)
+    context.add_os_installer_key(OS_ARCH, PACMAN_INSTALLER)
+    context.set_default_os_installer_key(OS_ARCH, lambda self: PACMAN_INSTALLER)
 
 
 def pacman_detect_single(p):

--- a/src/rosdep2/platforms/nix.py
+++ b/src/rosdep2/platforms/nix.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2019, Ben Wolsieffer
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Author Ben Wolsieffer/benwolsieffer@gmail.com
+import subprocess
+
+from rospkg.os_detect import OS_NIXOS
+
+from ..installers import PackageManagerInstaller
+
+NIX_INSTALLER = 'nix'
+
+
+def register_installers(context):
+    context.set_installer(NIX_INSTALLER, NixInstaller())
+
+
+def register_platforms(context):
+    context.add_os_installer_key(OS_NIXOS, NIX_INSTALLER)
+    context.set_default_os_installer_key(OS_NIXOS, lambda self: NIX_INSTALLER)
+
+
+def nix_detect(packages):
+    # Say that all packages are installed, because Nix handles installation
+    # automatically
+    return packages
+
+
+class NixInstaller(PackageManagerInstaller):
+
+    def __init__(self):
+        super(NixInstaller, self).__init__(nix_detect)
+
+    def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
+        raise NotImplementedError('Nix does not support installing packages through ROS')
+
+    def get_version_strings(self):
+        return subprocess.check_output(('nix', '--version'))


### PR DESCRIPTION
This is part of my effort to add support for [Nix](https://nixos.org/) to ROS. It depends on https://github.com/ros-infrastructure/rospkg/pull/171.

The Nix package manager is often used with NixOS, but it runs on any Linux distribution as well as macOS. In order to fit cleanly into the ROS infrastructure, I am pretending that Nix and NixOS have the traditional package manager and distribution relationship. This means that the rosdep OS key for Nix is `nixos`, even though this key may be used on multiple distributions. When packages are built, the build sandbox prevents OS detection from working anyway, so the `ROS_OS_OVERRIDE` environment variable is used to force the correct value.

`rosdep` will not be particularly useful to end users, because its imperative package management style does not fit Nix very well. Instead, it will be used to resolve dependencies when generating packages using `superflore`.

I am working on adding support for Nix to various ROS projects:
* https://github.com/lopsided98/rospkg/tree/nixos-support
* https://github.com/lopsided98/rosdep/tree/nixos-support
* https://github.com/lopsided98/superflore/tree/nixos-support

I maintain a [Superflore generated nixpkgs overlay](https://github.com/lopsided98/nix-ros-overlay) and have successfully built over 3600 ROS packages on a [Hydra](https://nixos.org/hydra/) build server (not yet publicly accessible)

I also made a small cleanup to the Arch Linux platform.