### PR TITLE
Add cosmic, disco, and eoan suites and remove suites older than…

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: ca-certificates, python3-rospkg (>= 1.1.8), python3-yaml, python3-catk
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: ca-certificates, python3-rospkg (>= 1.1.8), python3-yaml, python3-catk
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
These are now live on the ROS bootstrap repository and future releases should be pushed to them as well.