### PR TITLE
Guard next(inter)

### DIFF
--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -140,20 +140,18 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
 
         header = 'Package: %s' % p
         # proceed to Package header
-        while True:
-            try:
-                if next(lines) == header:
-                    break
-            except StopIteration:
-                break
+        try:
+            while next(lines) != header:
+                pass
+        except StopIteration:
+            pass
 
         # proceed to versions section
-        while True:
-            try:
-                if next(lines) == 'Versions: ':
-                    break
-            except StopIteration:
-                break
+        try:
+            while next(lines) != 'Versions: ':
+                pass
+        except StopIteration:
+            pass
 
         # virtual packages don't have versions
         try:
@@ -164,12 +162,11 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
             break
 
         # proceed to reserve provides section
-        while True:
-            try:
-                if next(lines) == 'Reverse Provides: ':
-                    break
-            except StopIteration:
-                break
+        try:
+            while next(lines) != 'Reverse Provides: ':
+                pass
+        except StopIteration:
+            pass
 
         pr = [line.split(' ', 2)[0] for line in lines]
         if pr:

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -140,21 +140,36 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
 
         header = 'Package: %s' % p
         # proceed to Package header
-        while next(lines) != header:
-            pass
+        while True:
+            try:
+                if next(lines) == header:
+                    break
+            except StopIteration:
+                break
 
         # proceed to versions section
-        while next(lines) != 'Versions: ':
-            pass
+        while True:
+            try:
+                if next(lines) == 'Versions: ':
+                    break
+            except StopIteration:
+                break
 
         # virtual packages don't have versions
-        if next(lines) != '':
-            yield p, False, None
-            continue
+        try:
+            if next(lines) != '':
+                yield p, False, None
+                continue
+        except StopIteration:
+            break
 
         # proceed to reserve provides section
-        while next(lines) != 'Reverse Provides: ':
-            pass
+        while True:
+            try:
+                if next(lines) == 'Reverse Provides: ':
+                    break
+            except StopIteration:
+                break
 
         pr = [line.split(' ', 2)[0] for line in lines]
         if pr:


### PR DESCRIPTION
Catch possible `StopIteration` exception on `next(iter)` call.

This PR replaces #695 which is not passing CI.
Fix #691

Signed-off-by: artivis <jeremie.deray@canonical.com>