### PR TITLE
tests: don't assume euid != 0

### DIFF
--- a/test/test_rosdep_installers.py
+++ b/test/test_rosdep_installers.py
@@ -28,6 +28,7 @@
 from __future__ import print_function
 
 from contextlib import contextmanager
+from mock import patch
 import os
 import sys
 try:
@@ -583,7 +584,8 @@ def fakeout():
     sys.stderr = realstderr
 
 
-def test_RosdepInstaller_install_resolved():
+@patch('rosdep2.installers.os.geteuid', return_value=1)
+def test_RosdepInstaller_install_resolved(mock_geteuid):
     from rosdep2 import create_default_installer_context
     from rosdep2.lookup import RosdepLookup
     from rosdep2.installers import RosdepInstaller

--- a/test/test_rosdep_main.py
+++ b/test/test_rosdep_main.py
@@ -162,7 +162,8 @@ class TestRosdepMain(unittest.TestCase):
             pass
 
     @patch('rosdep2.platforms.debian.read_stdout')
-    def test_install(self, mock_read_stdout):
+    @patch('rosdep2.installers.os.geteuid', return_value=1)
+    def test_install(self, mock_geteuid, mock_read_stdout):
         sources_cache = get_cache_dir()
         cmd_extras = ['-c', sources_cache]
         catkin_tree = get_test_catkin_tree_dir()

--- a/test/test_rosdep_opensuse.py
+++ b/test/test_rosdep_opensuse.py
@@ -41,21 +41,24 @@ def test_ZypperInstaller():
     from rosdep2.platforms.opensuse import ZypperInstaller
 
     @patch.object(ZypperInstaller, 'get_packages_to_install')
-    def test(mock_method):
+    def test(expected_prefix, mock_method):
         installer = ZypperInstaller()
         mock_method.return_value = []
         assert [] == installer.get_install_command(['fake'])
+        mock_method.return_value = ['a', 'b']
 
         # no interactive option with YUM
-        mock_method.return_value = ['a', 'b']
-        expected = [['sudo', '-H', 'zypper', 'install', '-yl', 'a', 'b']]
+        expected = [expected_prefix + ['zypper', 'install', '-yl', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False)
         assert val == expected, val
-        expected = [['sudo', '-H', 'zypper', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['zypper', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:
-        test()
+        with patch('rosdep2.installers.os.geteuid', return_value=1):
+            test(['sudo', '-H'])
+        with patch('rosdep2.installers.os.geteuid', return_value=0):
+            test([])
     except AssertionError:
         traceback.print_exc()
         raise

--- a/test/test_rosdep_redhat.py
+++ b/test/test_rosdep_redhat.py
@@ -80,27 +80,30 @@ def test_DnfInstaller():
     from rosdep2.platforms.redhat import DnfInstaller
 
     @patch.object(DnfInstaller, 'get_packages_to_install')
-    def test(mock_method):
+    def test(expected_prefix, mock_method):
         installer = DnfInstaller()
         mock_method.return_value = []
         assert [] == installer.get_install_command(['fake'])
 
         # no interactive option with YUM
         mock_method.return_value = ['a', 'b']
-        expected = [['sudo', '-H', 'dnf', '--assumeyes', '--quiet', '--setopt=strict=0', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['dnf', '--assumeyes', '--quiet', '--setopt=strict=0', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False, quiet=True)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'dnf', '--quiet', '--setopt=strict=0', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['dnf', '--quiet', '--setopt=strict=0', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True, quiet=True)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'dnf', '--assumeyes', '--setopt=strict=0', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['dnf', '--assumeyes', '--setopt=strict=0', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False, quiet=False)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'dnf', '--setopt=strict=0', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['dnf', '--setopt=strict=0', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True, quiet=False)
         assert val == expected, val + expected
     try:
-        test()
+        with patch('rosdep2.installers.os.geteuid', return_value=1):
+            test(['sudo', '-H'])
+        with patch('rosdep2.installers.os.geteuid', return_value=0):
+            test([])
     except AssertionError:
         traceback.print_exc()
         raise
@@ -110,27 +113,30 @@ def test_YumInstaller():
     from rosdep2.platforms.redhat import YumInstaller
 
     @patch.object(YumInstaller, 'get_packages_to_install')
-    def test(mock_method):
+    def test(expected_prefix, mock_method):
         installer = YumInstaller()
         mock_method.return_value = []
         assert [] == installer.get_install_command(['fake'])
 
         # no interactive option with YUM
         mock_method.return_value = ['a', 'b']
-        expected = [['sudo', '-H', 'yum', '--assumeyes', '--quiet', '--skip-broken', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['yum', '--assumeyes', '--quiet', '--skip-broken', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False, quiet=True)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'yum', '--quiet', '--skip-broken', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['yum', '--quiet', '--skip-broken', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True, quiet=True)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'yum', '--assumeyes', '--skip-broken', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['yum', '--assumeyes', '--skip-broken', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False, quiet=False)
         assert val == expected, val + expected
-        expected = [['sudo', '-H', 'yum', '--skip-broken', 'install', 'a', 'b']]
+        expected = [expected_prefix + ['yum', '--skip-broken', 'install', 'a', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True, quiet=False)
         assert val == expected, val + expected
     try:
-        test()
+        with patch('rosdep2.installers.os.geteuid', return_value=1):
+            test(['sudo', '-H'])
+        with patch('rosdep2.installers.os.geteuid', return_value=0):
+            test([])
     except AssertionError:
         traceback.print_exc()
         raise

--- a/test/test_rosdep_slackware.py
+++ b/test/test_rosdep_slackware.py
@@ -89,25 +89,28 @@ def test_SbotoolsInstaller():
     from rosdep2.platforms.slackware import SbotoolsInstaller
 
     @patch.object(SbotoolsInstaller, 'get_packages_to_install')
-    def test(mock_method):
+    def test(expected_prefix, mock_method):
         installer = SbotoolsInstaller()
         mock_method.return_value = []
         assert [] == installer.get_install_command(['fake'])
 
         mock_method.return_value = ['a', 'b']
 
-        expected = [['sudo', '-H', 'sboinstall', '-r', 'a'],
-                    ['sudo', '-H', 'sboinstall', '-r', 'b']]
+        expected = [expected_prefix + ['sboinstall', '-r', 'a'],
+                    expected_prefix + ['sboinstall', '-r', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False)
         assert val == expected, val
 
-        expected = [['sudo', '-H', 'sboinstall', 'a'],
-                    ['sudo', '-H', 'sboinstall', 'b']]
+        expected = [expected_prefix + ['sboinstall', 'a'],
+                    expected_prefix + ['sboinstall', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
 
     try:
-        test()
+        with patch('rosdep2.installers.os.geteuid', return_value=1):
+            test(['sudo', '-H'])
+        with patch('rosdep2.installers.os.geteuid', return_value=0):
+            test([])
     except AssertionError:
         traceback.print_exc()
         raise
@@ -159,25 +162,28 @@ def test_SlackpkgInstaller():
     from rosdep2.platforms.slackware import SlackpkgInstaller
 
     @patch.object(SlackpkgInstaller, 'get_packages_to_install')
-    def test(mock_method):
+    def test(expected_prefix, mock_method):
         installer = SlackpkgInstaller()
         mock_method.return_value = []
         assert [] == installer.get_install_command(['fake'])
 
         mock_method.return_value = ['a', 'b']
 
-        expected = [['sudo', '-H', 'slackpkg', 'install', 'a'],
-                    ['sudo', '-H', 'slackpkg', 'install', 'b']]
+        expected = [expected_prefix + ['slackpkg', 'install', 'a'],
+                    expected_prefix + ['slackpkg', 'install', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False)
         assert val == expected, val
 
-        expected = [['sudo', '-H', 'slackpkg', 'install', 'a'],
-                    ['sudo', '-H', 'slackpkg', 'install', 'b']]
+        expected = [expected_prefix + ['slackpkg', 'install', 'a'],
+                    expected_prefix + ['slackpkg', 'install', 'b']]
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
 
     try:
-        test()
+        with patch('rosdep2.installers.os.geteuid', return_value=1):
+            test(['sudo', '-H'])
+        with patch('rosdep2.installers.os.geteuid', return_value=0):
+            test([])
     except AssertionError:
         traceback.print_exc()
         raise


### PR DESCRIPTION
If tests rely on the environment being a certain way, they should ensure it meets expectations. This PR fixes #702 by updating the tests to ensure they're testing multiple euid conditions, and setting it explicitly where required.