### PR TITLE
Update shebang to python3

### DIFF
--- a/scripts/rosdep
+++ b/scripts/rosdep
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from rosdep2.main import rosdep_main
 rosdep_main()


### PR DESCRIPTION
It seems the debian install is broken without this, e.g:

```
$ rosdep
Traceback (most recent call last):
  File "/usr/bin/rosdep", line 3, in <module>
    from rosdep2.main import rosdep_main
ImportError: No module named rosdep2.main
```