### PR TITLE
Set ROS_PYTHON_VERSION if unset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version=__version__,  # noqa:F821
     packages=['rosdep2', 'rosdep2.ament_packages', 'rosdep2.platforms'],
     package_dir={'': 'src'},
-    install_requires=['catkin_pkg >= 0.4.0', 'rospkg >= 1.1.8', 'rosdistro >= 0.7.0', 'PyYAML >= 3.1'],
+    install_requires=['catkin_pkg >= 0.4.0', 'rospkg >= 1.1.8', 'rosdistro >= 0.7.5', 'PyYAML >= 3.1'],
     test_suite='nose.collector',
     test_requires=['mock', 'nose >= 1.0'],
     scripts=['scripts/rosdep', 'scripts/rosdep-source'],

--- a/src/rosdep2/cache_tools.py
+++ b/src/rosdep2/cache_tools.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2012, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import hashlib
+import os
+import tempfile
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+PICKLE_CACHE_EXT = '.pickle'
+
+def compute_filename_hash(key_filenames):
+    sha_hash = hashlib.sha1()
+    if isinstance(key_filenames, list):
+        for key in key_filenames:
+            sha_hash.update(key.encode())
+    else:
+        sha_hash.update(key_filenames.encode())
+    return sha_hash.hexdigest()
+
+
+def write_cache_file(source_cache_d, key_filenames, rosdep_data):
+    """
+    :param source_cache_d: directory to write cache file to
+    :param key_filenames: filename (or list of filenames) to be used in hashing
+    :param rosdep_data: dictionary of data to serialize as YAML
+    :returns: name of file where cache is stored
+    :raises: :exc:`OSError` if cannot write to cache file/directory
+    :raises: :exc:`IOError` if cannot write to cache file/directory
+    """
+    if not os.path.exists(source_cache_d):
+        os.makedirs(source_cache_d)
+    key_hash = compute_filename_hash(key_filenames)
+    filepath = os.path.join(source_cache_d, key_hash)
+    try:
+        write_atomic(filepath + PICKLE_CACHE_EXT, pickle.dumps(rosdep_data, 2), True)
+    except OSError as e:
+        raise CachePermissionError('Failed to write cache file: ' + str(e))
+    try:
+        os.unlink(filepath)
+    except OSError:
+        pass
+    return filepath
+
+
+def write_atomic(filepath, data, binary=False):
+    # write data to new file
+    fd, filepath_tmp = tempfile.mkstemp(prefix=os.path.basename(filepath) + '.tmp.', dir=os.path.dirname(filepath))
+
+    if (binary):
+        fmode = 'wb'
+    else:
+        fmode = 'w'
+
+    with os.fdopen(fd, fmode) as f:
+        f.write(data)
+        f.close()
+
+    try:
+        # switch file atomically (if supported)
+        os.rename(filepath_tmp, filepath)
+    except OSError:
+        # fall back to non-atomic operation
+        try:
+            os.unlink(filepath)
+        except OSError:
+            pass
+        try:
+            os.rename(filepath_tmp, filepath)
+        except OSError:
+            os.unlink(filepath_tmp)

--- a/src/rosdep2/cache_tools.py
+++ b/src/rosdep2/cache_tools.py
@@ -29,12 +29,15 @@ import hashlib
 import os
 import tempfile
 
+from .core import CachePermissionError
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
 PICKLE_CACHE_EXT = '.pickle'
+
 
 def compute_filename_hash(key_filenames):
     sha_hash = hashlib.sha1()

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -384,6 +384,11 @@ def _rosdep_main(args):
     if options.ros_distro:
         os.environ['ROS_DISTRO'] = options.ros_distro
 
+    if 'ROS_PYTHON_VERSION' not in os.environ:
+        print('WARNING: ROS_PYTHON_VERSION is unset. Defaulting to {}'.format(sys.version[0]), file=sys.stderr)
+        # Default to same python version used to invoke rosdep
+        os.environ['ROS_PYTHON_VERSION'] = sys.version[0]
+
     # Convert list of keys to dictionary
     options.as_root = dict((k, str_to_bool(v)) for k, v in key_list_to_dict(options.as_root).items())
 

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -383,6 +383,13 @@ def _rosdep_main(args):
     args = args[1:]
 
     if options.ros_distro:
+        if 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] != options.ros_distro:
+            # user has a different workspace sourced, use --rosdistro
+            print('WARNING: given --rosdistro {} but ROS_DISTRO is "{}". Ignoring environment.'.format(
+                options.ros_distro, os.environ['ROS_DISTRO']))
+            # Use python version from --rosdistro
+            if 'ROS_PYTHON_VERSION' in os.environ:
+                del os.environ['ROS_PYTHON_VERSION']
         os.environ['ROS_DISTRO'] = options.ros_distro
 
     # Convert list of keys to dictionary
@@ -393,11 +400,11 @@ def _rosdep_main(args):
     elif command not in ['fix-permissions']:
         setup_proxy_opener()
 
-    if 'ROS_PYTHON_VERSION' not in os.environ and options.ros_distro:
+    if 'ROS_PYTHON_VERSION' not in os.environ and 'ROS_DISTRO' in os.environ:
         # Set python version to version used by ROS distro
         python_versions = MetaDatabase().get('ROS_PYTHON_VERSION')
-        if options.ros_distro in python_versions:
-            os.environ['ROS_PYTHON_VERSION'] = str(python_versions[options.ros_distro])
+        if os.environ['ROS_DISTRO'] in python_versions:
+            os.environ['ROS_PYTHON_VERSION'] = str(python_versions[os.environ['ROS_DISTRO']])
 
     if 'ROS_PYTHON_VERSION' not in os.environ:
         # Default to same python version used to invoke rosdep

--- a/src/rosdep2/meta.py
+++ b/src/rosdep2/meta.py
@@ -98,7 +98,7 @@ class MetaDatabase:
     def set(self, category, metadata):
         """Add or overwrite metadata in the cache."""
         wrapper = CacheWrapper(category, metadata)
-        print(category, metadata)
+        # print(category, metadata)
         write_cache_file(self._cache_dir, category, wrapper)
         self._loaded[category] = wrapper
 

--- a/src/rosdep2/meta.py
+++ b/src/rosdep2/meta.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import copy
+import os
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+import rospkg
+
+from ._version import __version__
+from .cache_tools import compute_filename_hash
+from .cache_tools import write_cache_file
+from .cache_tools import PICKLE_CACHE_EXT
+
+"""
+Rosdep needs to store data that isn't used to resolve rosdep keys, but needs to be cached during
+`rosdep update`.
+"""
+
+META_CACHE_DIR = 'meta.cache'
+
+
+def get_meta_cache_dir():
+    """Return storage location for cached meta data."""
+    ros_home = rospkg.get_ros_home()
+    return os.path.join(ros_home, 'rosdep', META_CACHE_DIR)
+
+
+class MetaDatabase:
+    """
+    Store and retrieve metadata from rosdep cache.
+
+    This data is fetched during `rosdep update`, but is not a source for resolving rosdep keys.
+    """
+
+    class CacheWrapper:
+        """Make it possible to introspect cache in case some future bug needs to be worked around."""
+
+        def __init__(self, category, data):
+            # The version of rosdep that wrote the category
+            self.rosdep_version = __version__
+            # The un-hashed name of the category
+            self.category_name = category
+            # The stuff being stored
+            self.data = data
+
+        @property
+        def data(self):
+            # If cached data type is mutable, don't allow modifications to what's been loaded
+            return copy.deepcopy(self.__data)
+
+        @data.setter
+        def data(self, value):
+            self.__data = copy.deepcopy(value)
+
+    def __init__(self):
+        self._cache_dir = get_meta_cache_dir()
+        self._loaded = {}
+
+    def set(self, category, metadata):
+        """Add or overwrite metadata in the cache."""
+        wrapper = self.CacheWrapper(category, metadata)
+        print(category, metadata)
+        write_cache_file(self._cache_dir, category, wrapper)
+        self._loaded[category] = wrapper
+
+    def get(self, category):
+        """Return metadata in the cache, or None if there is no cache entry."""
+        if category not in self._loaded:
+            self._load_from_cache(category, self._cache_dir)
+
+        if category in self._loaded:
+            return self._loaded[category].data
+
+    def _load_from_cache(self, category, cache_dir):
+        filename = compute_filename_hash(category) + PICKLE_CACHE_EXT
+        try:
+            with open(os.path.join(self._cache_dir, filename), 'rb') as cache_file:
+                self._loaded[category] = pickle.loads(cache_file.read())
+        except FileNotFoundError:
+            pass

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: ca-certificates, python-rospkg (>= 1.1.8), python-yaml, python-catkin-pkg (>= 0.4.0), python-rosdistro (>= 0.7.0), sudo
-Depends3: ca-certificates, python3-rospkg (>= 1.1.8), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.7.0), sudo
+Depends: ca-certificates, python-rospkg (>= 1.1.8), python-yaml, python-catkin-pkg (>= 0.4.0), python-rosdistro (>= 0.7.5), sudo
+Depends3: ca-certificates, python3-rospkg (>= 1.1.8), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.7.5), sudo
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import os
+import sys
+
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:
+    import tempfile
+    import shutil
+
+    class TemporaryDirectory(object):
+        """Python 2 compatible class."""
+
+        def __init__(self):
+            self.name = None
+
+        def __enter__(self):
+            self.name = tempfile.mkdtemp()
+            return self.name
+
+        def __exit__(self, t, v, tb):
+            shutil.rmtree(self.name)
+
+from rosdep2.meta import MetaDatabase
+
+
+def test_metadatabase_set_get():
+    with TemporaryDirectory() as tmpdir:
+        db = MetaDatabase(cache_dir=tmpdir)
+        db.set('fruit', 'tomato')
+        assert 'tomato' == db.get('fruit')
+
+
+def test_metadatabase_get_none():
+    with TemporaryDirectory() as tmpdir:
+        db = MetaDatabase(cache_dir=tmpdir)
+        assert db.get('fruit') is None
+
+
+def test_metadatabase_get_mutate_get():
+    with TemporaryDirectory() as tmpdir:
+        db = MetaDatabase(cache_dir=tmpdir)
+        mutable = [1, 2, 3]
+        db.set('category', mutable)
+        mutable.append(4)
+        assert [1, 2, 3] == db.get('category')
+
+
+def test_metadatabase_set_set_get():
+    with TemporaryDirectory() as tmpdir:
+        db = MetaDatabase(cache_dir=tmpdir)
+        db.set('fruit', 'tomato')
+        db.set('fruit', 'orange')
+        assert 'orange' == db.get('fruit')
+
+
+def test_metadatabase_set_load_from_disk_get():
+    with TemporaryDirectory() as tmpdir:
+        db1 = MetaDatabase(cache_dir=tmpdir)
+        db1.set('fruit', 'apple')
+
+        db2 = MetaDatabase(cache_dir=tmpdir)
+        assert 'apple' == db2.get('fruit')


### PR DESCRIPTION
Requires ros-infrastructure/rosdistro#145

This sets `ROS_PYTHON_VERSION` if it is unset. This enables rosdep to resolve conditional dependencies using `ROS_PYTHON_VERSION` before building a ROS distribution from source.

If `--rosdistro` is given, it tries to use the `python_version` field from the rosdistro index. Otherwise, it uses the same version of python used to invoke rosdep as mentioned in ros-infrastructure/rep#201

To try out the `python_version` attribute, update using a custom rosdistro index url

```
ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/dirk-thomas/add-python_version-to-index/index-v4.yaml rosdep update
```

To test, get a package using conditional dependencies and run the commands below with no ROS workspace sourced.

```
git clone https://github.com/ros/urdf_parser_py.git -b py3-port
```

Before this PR
```
(env3) sloretz@7895d0788081:/tmp$ rosdep check --from-paths urdf_parser_py/ --ignore-src --skip-keys="rospy catkin"
All system dependencies have been satisfied
```

no rosdistro after this PR
```
sloretz@b0e9deb48a5e:~$ rosdep check --from-paths urdf_parser_py/ --ignore-src --skip-keys="rospy catkin"
WARNING: ROS_PYTHON_VERSION is unset. Defaulting to 3
System dependencies have not been satisfied:
apt	python3-lxml
apt	python3-mock
```

melodic
```
sloretz@b0e9deb48a5e:~$ rosdep check --rosdistro melodic --from-paths urdf_parser_py/ --ignore-src --skip-keys="rospy catkin"
System dependencies have not been satisfied:
apt	python-lxml
apt	python-yaml
apt	python-mock
```

noetic
```
sloretz@b0e9deb48a5e:~$ rosdep check --rosdistro noetic --from-paths urdf_parser_py/ --ignore-src --skip-keys="rospy catkin"
System dependencies have not been satisfied:
apt	python3-lxml
apt	python3-mock
```

