### PR TITLE
Add default kwarg to MetaDatabase.get()

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -402,7 +402,7 @@ def _rosdep_main(args):
 
     if 'ROS_PYTHON_VERSION' not in os.environ and 'ROS_DISTRO' in os.environ:
         # Set python version to version used by ROS distro
-        python_versions = MetaDatabase().get('ROS_PYTHON_VERSION')
+        python_versions = MetaDatabase().get('ROS_PYTHON_VERSION', default=[])
         if os.environ['ROS_DISTRO'] in python_versions:
             os.environ['ROS_PYTHON_VERSION'] = str(python_versions[os.environ['ROS_DISTRO']])
 

--- a/src/rosdep2/meta.py
+++ b/src/rosdep2/meta.py
@@ -102,13 +102,15 @@ class MetaDatabase:
         write_cache_file(self._cache_dir, category, wrapper)
         self._loaded[category] = wrapper
 
-    def get(self, category):
+    def get(self, category, default=None):
         """Return metadata in the cache, or None if there is no cache entry."""
         if category not in self._loaded:
             self._load_from_cache(category, self._cache_dir)
 
         if category in self._loaded:
             return self._loaded[category].data
+
+        return default
 
     def _load_from_cache(self, category, cache_dir):
         filename = compute_filename_hash(category) + PICKLE_CACHE_EXT

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -65,6 +65,14 @@ def test_metadatabase_get_none():
         assert db.get('fruit') is None
 
 
+def test_metadatabase_get_default():
+    with TemporaryDirectory() as tmpdir:
+        db = MetaDatabase(cache_dir=tmpdir)
+        assert db.get('fruit', default='foo') == 'foo'
+        db.set('fruit', 'tomato')
+        assert db.get('fruit', default='foo') != 'foo'
+
+
 def test_metadatabase_get_mutate_get():
     with TemporaryDirectory() as tmpdir:
         db = MetaDatabase(cache_dir=tmpdir)


### PR DESCRIPTION
I think this fixes #720

It should fix broken `rosdep` CLI when a kinetic workspace is sourced. I suspect the environment is:

* There is an existing `kinetic` install, and it's sourced in the current terminal
* `rosdep update` has been successfully run in the past.
* `ros_environment` on `kinetic` does not set `ROS_PYTHON_VERSION`, but it does set `ROS_DISTRO`

Then I think what happened is:

1. Rosdep saw `ROS_DISTRO`, but no `ROS_PYTHON_VERSION`, so it tried to ask the cache which python version to use.
1. `Metadatabase.get()` had no data about the python version since `rosdep update` hasn't been run since the `python_version` info was added to the rosdistro index
1. Code here tried to treat the return value of `None` as an iterable type :boom:

@acarrillo Mind trying this pull request on your system?