### PR TITLE
improve support for null entries

### DIFF
--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -144,6 +144,9 @@ class RosdepDefinition(object):
                                 return_key = installer_key
                                 break
 
+        # Check if the rule is null
+        if data is None:
+            raise ResolutionError(rosdep_key, self.data, os_name, os_version, '[%s] defined as "not available" for OS version [%s]' % (rosdep_key, os_version))
         if type(data) not in (dict, list, type('str')):
             raise InvalidData('rosdep OS definition for [%s:%s] must be a dictionary, string, or list: %s' % (self.rosdep_key, os_name, data), origin=self.origin)
 

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -174,7 +174,7 @@ class ResolutionError(Exception):
 \trosdep key : %s
 \tOS name    : %s
 \tOS version : %s
-\tData:\n%s""" % (self.args[0], self.rosdep_key, self.os_name, self.os_version, pretty_data)
+\tData:\n%s""" % (self.args[0], self.rosdep_key, self.os_name, self.os_version, pretty_data.replace('\n', '\n\t\t'))
 
 
 class RosdepView(object):

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -174,7 +174,7 @@ class ResolutionError(Exception):
 \trosdep key : %s
 \tOS name    : %s
 \tOS version : %s
-\tData: %s""" % (self.args[0], self.rosdep_key, self.os_name, self.os_version, pretty_data)
+\tData:\n%s""" % (self.args[0], self.rosdep_key, self.os_name, self.os_version, pretty_data)
 
 
 class RosdepView(object):

--- a/test/test_rosdep_lookup.py
+++ b/test/test_rosdep_lookup.py
@@ -182,6 +182,26 @@ def test_RosdepDefinition():
     val = definition.get_rule_for_platform('ubuntu', 'trusty', ['apt', 'source', 'pip'], 'apt')
     assert val == ('apt', ['libtinyxml2-dev']), val
 
+    definition = RosdepDefinition('trusty_only_key', {'ubuntu': {'*': None, 'trusty': ['trusty_only_pkg']}, 'debian': None}, 'wildcard.txt')
+    try:
+        val = definition.get_rule_for_platform('ubuntu', 'lucid', ['apt', 'source', 'pip'], 'apt')
+        assert False, 'should have raised: %s' % (str(val))
+    except ResolutionError as e:
+        assert e.rosdep_key == 'trusty_only_key'
+        assert e.os_name == 'ubuntu'
+        assert e.os_version == '*'
+        # tripwire
+        str(e)
+    try:
+        val = definition.get_rule_for_platform('debian', 'stretch', ['apt', 'source', 'pip'], 'apt')
+        assert False, 'should have raised: %s' % (str(val))
+    except ResolutionError as e:
+        assert e.rosdep_key == 'trusty_only_key'
+        assert e.os_name == 'debian'
+        assert e.os_version == 'stretch'
+        # tripwire
+        str(e)
+
     # test reverse merging OS things (first is default)
     definition = RosdepDefinition('test', {'debian': 'libtest-dev'}, 'fake-1.txt')
     # rule should work as expected before reverse-merge


### PR DESCRIPTION
syntax like 'ubuntu: null' will now be raising ResolutionError with
relevant error message instead of InvalidData

This came up recently with https://github.com/ros/rosdistro/pull/21906
This should also fix / improve error message for issues like https://github.com/ros-infrastructure/rosdep/issues/689

<details>

before:
```
root@cd07c77952b3:/# rosdep resolve apparmor --os fedora:30

ERROR: Rosdep experienced an error: rosdep OS definition for [apparmor:fedora] must be a dictionary, string, or list: None
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.17.1

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/rosdep2/main.py", line 144, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/usr/local/lib/python3.6/dist-packages/rosdep2/main.py", line 424, in _rosdep_main
    return _rosdep_args_handler(command, parser, options, args)
  File "/usr/local/lib/python3.6/dist-packages/rosdep2/main.py", line 446, in _rosdep_args_handler
    return command_handlers[command](args, options)
  File "/usr/local/lib/python3.6/dist-packages/rosdep2/main.py", line 865, in command_resolve
    rule_installer, rule = d.get_rule_for_platform(os_name, os_version, installer_keys, default_key)
  File "/usr/local/lib/python3.6/dist-packages/rosdep2/lookup.py", line 151, in get_rule_for_platform
    raise InvalidData('rosdep OS definition for [%s:%s] must be a dictionary, string, or list: %s' % (self.rosdep_key, os_name, data), origin=self.origin)
rosdep2.core.InvalidData: rosdep OS definition for [apparmor:fedora] must be a dictionary, string, or list: None

```

after:

```
root@cd07c77952b3:/# rosdep resolve apparmor --os fedora:30

ERROR: [apparmor] defined as "not available" for OS version [30]

[apparmor] defined as "not available" for OS version [30]
	rosdep key : apparmor
	OS name    : fedora
	OS version : 30
	Data: 
debian:
- apparmor
fedora: null
ubuntu:
- apparmor

```

</details>

Second commit improves the formatting, but can be ommitted if disruptive as it;s not really related to this fix

<details>

before:
```
root@cd07c77952b3:/# rosdep resolve apparmor --os fedora:30

ERROR: [apparmor] defined as "not available" for OS version [30]

[apparmor] defined as "not available" for OS version [30]
	rosdep key : apparmor
	OS name    : fedora
	OS version : 30
	Data: debian:
- apparmor
fedora: null
ubuntu:
- apparmor
```

after:
```
root@cd07c77952b3:/# rosdep resolve apparmor --os fedora:30

ERROR: [apparmor] defined as "not available" for OS version [30]

[apparmor] defined as "not available" for OS version [30]
	rosdep key : apparmor
	OS name    : fedora
	OS version : 30
	Data: 
debian:
- apparmor
fedora: null
ubuntu:
- apparmor
```
</details>



Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>