### PR TITLE
openSUSE package query  and install enhancements

### DIFF
--- a/src/rosdep2/platforms/opensuse.py
+++ b/src/rosdep2/platforms/opensuse.py
@@ -31,6 +31,7 @@ import subprocess
 
 from rospkg.os_detect import OS_OPENSUSE
 
+from .pip import PIP_INSTALLER
 from .source import SOURCE_INSTALLER
 from ..installers import PackageManagerInstaller
 
@@ -44,6 +45,7 @@ def register_installers(context):
 
 def register_platforms(context):
     context.add_os_installer_key(OS_OPENSUSE, SOURCE_INSTALLER)
+    context.add_os_installer_key(OS_OPENSUSE, PIP_INSTALLER)
     context.add_os_installer_key(OS_OPENSUSE, ZYPPER_INSTALLER)
     context.set_default_os_installer_key(OS_OPENSUSE, lambda self: ZYPPER_INSTALLER)
 

--- a/src/rosdep2/platforms/opensuse.py
+++ b/src/rosdep2/platforms/opensuse.py
@@ -53,7 +53,7 @@ def register_platforms(context):
 def rpm_detect(packages):
     installed = []
     for p in packages:
-        if not subprocess.call(['rpm', '-q', p]):
+        if not subprocess.call(['rpm', '-q', '--whatprovides', p]):
             installed.append(p)
     return installed
 


### PR DESCRIPTION
Enable pip installer, use rpm capabilities for package lookup to prevent package renaming issues.

For example, in python.yml the `python-numpy` dependency is resolved to the opensuse rpm package `python-numpy` which is absent. But the package `python2-numpy` provides it as a capability as shown below:
```
$ rpm -q --provides python2-numpy
python-numpy = 1.16.5
python2-numpy = 1.16.5-2.1
python2-numpy(x86-64) = 1.16.5-2.1
```

So instead of matching the exact package name at dependency resolving the capabilities should be queried (`--whatprovides` flag).

```
$ rpm -q --whatprovides python2-numpy
python2-numpy-1.16.5-2.1.x86_64
$ rpm -q --whatprovides python-numpy
python2-numpy-1.16.5-2.1.x86_64
```

Of course, if none of the installed package provides the given capability the return code is still non-zero:

```
$ rpm -q --whatprovides anyunknowncap; echo $?
no package provides anyunknowncap
1
```