### PR TITLE
[update] Allow to process single ROS distro, fix 723

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -652,6 +652,9 @@ def command_update(options):
     except IOError as e:
         print('ERROR: error loading sources list:\n\t%s' % (e), file=sys.stderr)
         return 1
+    except ValueError as e:
+        print('ERROR: invalid argument value provided:\n\t%s' % (e), file=sys.stderr)
+        return 1
     if error_occured:
         print('ERROR: Not all sources were able to be updated.\n[[[')
         for e in error_occured:

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -269,7 +269,7 @@ def setup_environment_variables(ros_distro):
     """
     Set environment variables needed to find ROS packages and evaluate conditional dependencies.
 
-    :param rosdistro: The requested ROS distro passed on the CLI, or None
+    :param ros_distro: The requested ROS distro passed on the CLI, or None
     """
     if ros_distro is not None:
         if 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] != ros_distro:
@@ -355,7 +355,9 @@ def _rosdep_main(args):
     parser.add_option('--rosdistro', dest='ros_distro', default=None,
                       help='Explicitly sets the ROS distro to use, overriding '
                            'the normal method of detecting the ROS distro '
-                           'using the ROS_DISTRO environment variable.')
+                           'using the ROS_DISTRO environment variable. '
+                           "When used with the 'update' verb, "
+                           'only the specified distro will be updated.')
     parser.add_option('--as-root', default=[], action='append',
                       metavar='INSTALLER_KEY:<bool>', help='Override '
                       'whether sudo is used for a specific installer, '

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -643,7 +643,8 @@ def command_update(options):
             pass
         update_sources_list(success_handler=update_success_handler,
                             error_handler=update_error_handler,
-                            skip_eol_distros=not options.include_eol_distros)
+                            skip_eol_distros=not options.include_eol_distros,
+                            ros_distro=options.ros_distro)
         print('updated cache in %s' % (sources_cache_dir))
     except InvalidData as e:
         print('ERROR: invalid sources list file:\n\t%s' % (e), file=sys.stderr)

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -487,7 +487,14 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
     python_versions = {}
 
     print('Query rosdistro index %s' % get_index_url())
-    for dist_name in sorted(get_index().distributions.keys()):
+    distribution_name_list = sorted(get_index().distributions.keys())
+    if ros_distro not in distribution_name_list:
+        print(
+            'Requested distribution "%s" is not in the index.'
+            ' Ignoring ros_distro argument' % ros_distro)
+        ros_distro = None
+
+    for dist_name in distribution_name_list:
         distribution = get_index().distributions[dist_name]
         if ros_distro is not None:
             if dist_name != ros_distro:

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -487,23 +487,21 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
     python_versions = {}
 
     print('Query rosdistro index %s' % get_index_url())
-    distribution_name_list = sorted(get_index().distributions.keys())
-    if ros_distro not in distribution_name_list:
-        print(
-            'Requested distribution "%s" is not in the index.'
-            ' Ignoring ros_distro argument' % ros_distro)
-        ros_distro = None
+    distribution_names = get_index().distributions.keys()
+    if ros_distro is not None and ros_distro not in distribution_names:
+        raise ValueError(
+            'Requested distribution "%s" is not in the index.' % ros_distro)
 
-    for dist_name in distribution_name_list:
+    for dist_name in sorted(distribution_names):
         distribution = get_index().distributions[dist_name]
-        if ros_distro is not None:
-            if dist_name != ros_distro:
+        if dist_name != ros_distro:
+            if ros_distro is not None:
                 print('Skip distro "%s" different from requested "%s"' % (dist_name, ros_distro))
                 continue
-        if skip_eol_distros and dist_name != ros_distro:
-            if distribution.get('distribution_status') == 'end-of-life':
-                print('Skip end-of-life distro "%s"' % dist_name)
-                continue
+            if skip_eol_distros:
+                if distribution.get('distribution_status') == 'end-of-life':
+                    print('Skip end-of-life distro "%s"' % dist_name)
+                    continue
         print('Add distro "%s"' % dist_name)
         rds = RosDistroSource(dist_name)
         rosdep_data = get_gbprepo_as_rosdep_data(dist_name)

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -439,7 +439,7 @@ def _generate_key_from_urls(urls):
 
 def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
                         success_handler=None, error_handler=None,
-                        skip_eol_distros=False):
+                        skip_eol_distros=False, ros_distro=None):
     """
     Re-downloaded data from remote sources and store in cache.  Also
     update the cache index based on current sources.
@@ -489,7 +489,11 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
     print('Query rosdistro index %s' % get_index_url())
     for dist_name in sorted(get_index().distributions.keys()):
         distribution = get_index().distributions[dist_name]
-        if skip_eol_distros:
+        if ros_distro is not None:
+            if dist_name != ros_distro:
+                print('Skip distro "%s" different from requested "%s"' % (dist_name, ros_distro))
+                continue
+        if skip_eol_distros and dist_name != ros_distro:
             if distribution.get('distribution_status') == 'end-of-life':
                 print('Skip end-of-life distro "%s"' % dist_name)
                 continue


### PR DESCRIPTION
Fixes https://github.com/ros-infrastructure/rosdep/issues/723

Handling of `--rosdistro` argument in https://github.com/ros-infrastructure/rosdep/commit/99159096d2dade07d3400f8a55ac2ab7953809ff. Added a print for consistency with skipping EOL but it may be better to remove it.
https://github.com/ros-infrastructure/rosdep/commit/ff38f1e8484eb286f06c535ef71837d93c8718c9 preserves original behavior if the provided rosdistro name is unknown.

<details>

With existing rosdistro
```
root@cd278b6e5a50:/opt/rosdep# time rosdep update --rosdistro indigo
reading in sources list data from /etc/ros/rosdep/sources.list.d
Warning: running 'rosdep update' as root is not recommended.
  You should run 'sudo rosdep fix-permissions' and invoke 'rosdep update' again without sudo.
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
Skip distro "ardent" different from requested "indigo"
Skip distro "bouncy" different from requested "indigo"
Skip distro "crystal" different from requested "indigo"
Skip distro "dashing" different from requested "indigo"
Skip distro "eloquent" different from requested "indigo"
Skip distro "foxy" different from requested "indigo"
Skip distro "groovy" different from requested "indigo"
Skip distro "hydro" different from requested "indigo"
Add distro "indigo"
Skip distro "jade" different from requested "indigo"
Skip distro "kinetic" different from requested "indigo"
Skip distro "lunar" different from requested "indigo"
Skip distro "melodic" different from requested "indigo"
Skip distro "noetic" different from requested "indigo"
updated cache in /root/.ros/rosdep/sources.cache

real	0m4.136s
user	0m3.152s
sys	0m0.086s
```

With no-existing rosdistro
```
root@cd278b6e5a50:/opt/rosdep# time rosdep update --rosdistro indigooo
reading in sources list data from /etc/ros/rosdep/sources.list.d
Warning: running 'rosdep update' as root is not recommended.
  You should run 'sudo rosdep fix-permissions' and invoke 'rosdep update' again without sudo.
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
Requested distribution "indigooo" is not in the index. Ignoring ros_distro argument
Skip end-of-life distro "ardent"
Skip end-of-life distro "bouncy"
Add distro "crystal"
Add distro "dashing"
Add distro "eloquent"
Add distro "foxy"
Skip end-of-life distro "groovy"
Skip end-of-life distro "hydro"
Skip end-of-life distro "indigo"
Skip end-of-life distro "jade"
Add distro "kinetic"
Skip end-of-life distro "lunar"
Add distro "melodic"
Add distro "noetic"
updated cache in /root/.ros/rosdep/sources.cache

real	0m6.654s
user	0m5.032s
sys	0m0.046s

```

</details>

@wjwwood FYI