### PR TITLE
Fix runtime errors

### DIFF
--- a/scripts/rosdep
+++ b/scripts/rosdep
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-
-from rosdep2.main import rosdep_main
-rosdep_main()

--- a/scripts/rosdep-source
+++ b/scripts/rosdep-source
@@ -35,6 +35,7 @@ from __future__ import print_function
 import os
 import sys
 from optparse import OptionParser
+from multiprocessing import freeze_support
 
 from rosdep2 import InstallFailed
 from rosdep2.platforms import source
@@ -61,4 +62,5 @@ def install_main():
 
 
 if __name__ == '__main__':
+    freeze_support()
     install_main()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,12 @@ kwargs = {
     'install_requires': ['catkin_pkg >= 0.4.0', 'rospkg >= 1.1.10', 'rosdistro >= 0.7.5', 'PyYAML >= 3.1'],
     'test_suite': 'nose.collector',
     'test_requires': ['mock', 'nose >= 1.0'],
-    'scripts': ['scripts/rosdep', 'scripts/rosdep-source'],
+    'entry_points': {
+        'console_scripts': [
+            'rosdep = rosdep2.main:rosdep_main',
+        ],
+    },
+    'scripts': ['scripts/rosdep-source'],
     'author': 'Tully Foote, Ken Conley',
     'author_email': 'tfoote@osrfoundation.org',
     'url': 'http://wiki.ros.org/rosdep',


### PR DESCRIPTION
macOS 10.15
CPython 3.8.2 (installed with pyenv)
pyenv 1.2.16
pip 20.0.2

```
$ rosdep install --from src -ry

ERROR: Rosdep experienced an error: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.18.0

Traceback (most recent call last):
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/site-packages/rosdep2/main.py", line 144, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/site-packages/rosdep2/main.py", line 428, in _rosdep_main
   
ERROR: Rosdep experienced an error: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.18.0

Traceback (most recent call last):
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/site-packages/rosdep2/main.py", line 144, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/site-packages/rosdep2/main.py", line 428, in _rosdep_main
    return _package_args_handler(command, parser, options, args)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/site-packages/rosdep2/main.py", line 483, in _package_args_handler
    pkgs = find_catkin_packages_in(path, options.verbose)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/site-packages/rosdep2/catkin_packages.py", line 33, in find_catkin_packages_in
    packages = find_packages(path)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/site-packages/catkin_pkg/packages.py", line 89, in find_packages
    packages = find_packages_allowing_duplicates(basepath, exclude_paths=exclude_paths, exclude_subspaces=exclude_subspaces, warnings=warnings)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/site-packages/catkin_pkg/packages.py", line 139, in find_packages_allowing_duplicates
    pool = multiprocessing.Pool()
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/context.py", line 119, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild,
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/pool.py", line 212, in __init__
    self._repopulate_pool()
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/pool.py", line 303, in _repopulate_pool
    return self._repopulate_pool_static(self._ctx, self.Process,
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/pool.py", line 326, in _repopulate_pool_static
    w.start()
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/context.py", line 283, in _Popen
    return Popen(process_obj)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 42, in _launch
    prep_data = spawn.get_preparation_data(process_obj._name)
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/spawn.py", line 154, in get_preparation_data
    _check_not_importing_main()
  File "/Users/dan/.pyenv/versions/3.8.2/lib/python3.8/multiprocessing/spawn.py", line 134, in _check_not_importing_main
    raise RuntimeError('''
```
