### PR TITLE
Depend on modules packages only to allow co-installability.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -16,8 +16,8 @@ X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [rosdep_modules]
-Depends: ca-certificates, python-rospkg (>= 1.1.10), python-yaml, python-catkin-pkg (>= 0.4.0), python-rosdistro (>= 0.7.5), sudo
-Depends3: ca-certificates, python3-rospkg (>= 1.1.10), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.7.5), sudo
+Depends: ca-certificates, python-rospkg-modules (>= 1.1.10), python-yaml, python-catkin-pkg-modules (>= 0.4.0), python-rosdistro-modules (>= 0.7.5), sudo
+Depends3: ca-certificates, python3-rospkg-modules (>= 1.1.10), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), sudo
 Conflicts: python-rosdep (<< 0.18.0), python-rosdep2
 Conflicts3: python3-rosdep (<< 0.18.0), python3-rosdep2
 Replaces: python-rosdep (<< 0.18.0)


### PR DESCRIPTION
When the rosdep modules package was split in [#731] the module
dependencies weren't updated to only depend on modules packages
themselves which prevents rosdep modules for python2 and python3 from
actually being co-installable.

I haven't yet audited to make sure there's no cli usage of these tools
in the modules but it's Friday afternoon and I wanted to get this inked
before I walked away.

When I return to it I'll check for that before proceeding for reviews.