### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: rosdep
 
-on:
-- push: [action-jack, master]
-- pull_request: [action-jack, master]
+on: [push, pull_request]
 
 jobs:
     build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 name: rosdep
 
 on:
-  push: [action-jack, master]
-  pull_request: [action-jack, master]
+- push: [action-jack, master]
+- pull_request: [action-jack, master]
 
 jobs:
     build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: rosdep CI
+name: rosdep-ci
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
       strategy:
         matrix:
           os: [ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest]
-          python: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
+          python: [2.7, 3.5, 3.6, 3.7, 3.8]
           exclude:
           - os: ubuntu-16.04
             python: 3.6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest]
+          os: [ubuntu-16.04, ubuntu-18.04, macos-latest]
           python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
           exclude:
           - os: ubuntu-16.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,8 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-16.04, ubuntu-18.04, macos-latest]
-          python: [2.7, 3.5, 3.6, 3.7, 3.8]
+          os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest]
+          python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
           exclude:
           - os: ubuntu-16.04
             python: 3.6
@@ -15,6 +15,8 @@ jobs:
             python: 3.7
           - os: ubuntu-16.04
             python: 3.8
+          - os: ubuntu-16.04
+            python: 3.9  
           - os: ubuntu-18.04
             python: 3.5
           - os: macos-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 name: rosdep
 
 on:
-  push: [master]
-  pull_request: [master]
+  push: [action-jack, master]
+  pull_request: [action-jack, master]
 
 jobs:
     build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: rosdep
+name: rosdep CI
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           if [ '${{matrix.python}}' == "3.4"]; then python -m pip install PyYAML==5.2; fi
           python -m pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
           python -m pip install -e .
-          python -m pip nose coverage flake8 mock codecov
+          python -m pip install nose coverage flake8 mock codecov
       - name: Run tests
         run: |
           python -m nose --with-coverage --cover-package=rosdep2 --with-xunit test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest]
+          os: [ubuntu-16.04, ubuntu-18.04, macos-latest]
           python: [2.7, 3.5, 3.6, 3.7, 3.8]
           exclude:
           - os: ubuntu-16.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+name: rosdep
+
+on:
+  push: [master]
+  pull_request: [master]
+
+jobs:
+    build:
+      strategy:
+        matrix:
+          os: [ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest]
+          python: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
+          exclude:
+          - os: ubuntu-16.04
+            python: 3.6
+          - os: ubuntu-16.04
+            python: 3.7
+          - os: ubuntu-16.04
+            python: 3.8
+          - os: macos-latest
+            python: 3.4
+          - os: macos-latest
+            python: 3.5
+          - os: macos-latest
+            python: 3.6
+      name: rosdep tests
+      runs-on: ${{matrix.os}}
+
+      steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{matrix.python}}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.python}}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          if [ "${{matrix.python}}" == "3.4"]; then python -m pip install PyYAML==5.2; fi
+          python -m pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
+          python -m pip install -e .
+          python -m pip nose coverage flake8 mock codecov
+      - name: Run tests
+        run: |
+          python -m nose --with-coverage --cover-package=rosdep2 --with-xunit test
+      - name: Check coverage
+        run: |
+          python -m codecov
+
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          if [ "${{matrix.python}}" == "3.4"]; then python -m pip install PyYAML==5.2; fi
+          if [ '${{matrix.python}}' == "3.4"]; then python -m pip install PyYAML==5.2; fi
           python -m pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
           python -m pip install -e .
           python -m pip nose coverage flake8 mock codecov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ jobs:
             python: 3.7
           - os: ubuntu-16.04
             python: 3.8
-          - os: macos-latest
-            python: 3.4
+          - os: ubuntu-18.04
+            python: 3.5
           - os: macos-latest
             python: 3.5
           - os: macos-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          if [ '${{matrix.python}}' == "3.4"]; then python -m pip install PyYAML==5.2; fi
           python -m pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
           python -m pip install -e .
           python -m pip install nose coverage flake8 mock codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,8 @@
 language: python
 matrix:
   include:
-    - os: osx
-      language: generic
-      env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=2.7.14
-    - os: osx
-      language: generic
-      env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=3.6.4
-    - os: osx
-      language: generic
-      env:
-        - PYTHON_INSTALLER=brew
-        - PIP_USER_FLAG="--user"
-    - os: linux
-      python: 2.7
     - os: linux
       python: 3.4   # When support for 3.4 is removed unpin the PyYAML version below.
-    - os: linux
-      python: 3.5
-    - os: linux
-      python: 3.6
-    - os: linux
-      python: 3.7
-    - os: linux
-      python: 3.8
 
 # command to install dependencies
 install:


### PR DESCRIPTION
This is a pretty straight-ish port of our Travis CI coverage to GitHub actions. Unlike Travis's matrix strategy which allows the specification of exact combinations with GitHub's you can only exclude or modify (via include) combinations from the set cartesian product. The setup-python action from upstream doesn't support Python 3.4 so I wasn't able to preserve support for it.

You can see this GitHub action running on my fork here: https://github.com/nuclearsandwich/rosdep/actions?query=workflow%3Arosdep-ci