### PR TITLE
Set Python2-Depends-Name to allow releasing from Focal.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -12,6 +12,7 @@ Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -25,5 +26,6 @@ Replaces3: python3-rosdep (<< 0.18.0)
 Copyright-File: LICENSE
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Requires stdeb >= 0.9.1 and as a trade-off makes the created python 2 package uninstallable on Ubuntu Focal and later where the `python` package is called `python2` instead.