### PR TITLE
Use tool-specific user-agent to retrieve custom rules from websites

### DIFF
--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -35,9 +35,11 @@ import yaml
 try:
     from urllib.request import urlopen
     from urllib.error import URLError
+    import urllib.request as request
 except ImportError:
     from urllib2 import urlopen
     from urllib2 import URLError
+    import urllib2 as request
 try:
     import cPickle as pickle
 except ImportError:
@@ -47,6 +49,7 @@ from .cache_tools import compute_filename_hash, PICKLE_CACHE_EXT, write_atomic, 
 from .core import InvalidData, DownloadFailure, CachePermissionError
 from .gbpdistro_support import get_gbprepo_as_rosdep_data, download_gbpdistro_as_rosdep_data
 from .meta import MetaDatabase
+from ._version import __version__
 
 try:
     import urlparse
@@ -303,7 +306,13 @@ def download_rosdep_data(url):
         retrieved (e.g. 404, bad YAML format, server down).
     """
     try:
-        f = urlopen(url, timeout=DOWNLOAD_TIMEOUT)
+        # http/https URLs need custom requests to specify the user-agent, since some repositories reject
+        # requests from the default user-agent.
+        if url.startswith("http://") or url.startswith("https://"):
+            url_request = request.Request(url, headers={'User-Agent': 'rosdep/{version}'.format(version=__version__)})
+        else:
+            url_request = url
+        f = urlopen(url_request, timeout=DOWNLOAD_TIMEOUT)
         text = f.read()
         f.close()
         data = yaml.safe_load(text)


### PR DESCRIPTION
Fixes: https://github.com/ros-infrastructure/rosdep/issues/774
gitlab.com (and possibly other sites) reject urlopen() requests from the default user-agent used by urllib2. This PR adds a tool-specific user-agent in the request header for http and https when retrieving custom rules files.
With thanks to Christophe Bedard, who correctly identified the problem.
