### PR TITLE
Fix handling of installer version strings

### DIFF
--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -263,7 +263,7 @@ class AptInstaller(PackageManagerInstaller):
 
     def get_version_strings(self):
         output = subprocess.check_output(['apt-get', '--version'])
-        version = output.splitlines()[0].split(' ')[1]
+        version = output.splitlines()[0].split(b' ')[1].decode()
         return ['apt-get {}'.format(version)]
 
     def _get_install_commands_for_package(self, base_cmd, package_or_list):

--- a/src/rosdep2/platforms/gem.py
+++ b/src/rosdep2/platforms/gem.py
@@ -79,7 +79,7 @@ class GemInstaller(PackageManagerInstaller):
         super(GemInstaller, self).__init__(gem_detect, supports_depends=True)
 
     def get_version_strings(self):
-        gem_version = subprocess.check_output(['gem', '--version']).strip()
+        gem_version = subprocess.check_output(['gem', '--version']).strip().decode()
         return ['gem {}'.format(gem_version)]
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):

--- a/src/rosdep2/platforms/nix.py
+++ b/src/rosdep2/platforms/nix.py
@@ -59,4 +59,4 @@ class NixInstaller(PackageManagerInstaller):
         raise NotImplementedError('Nix does not support installing packages through ROS')
 
     def get_version_strings(self):
-        return subprocess.check_output(('nix', '--version'))
+        return subprocess.check_output(('nix', '--version')).decode()

--- a/src/rosdep2/platforms/openembedded.py
+++ b/src/rosdep2/platforms/openembedded.py
@@ -70,7 +70,7 @@ class OpkgInstaller(PackageManagerInstaller):
 
     def get_version_strings(self):
         output = subprocess.check_output(['opkg', '--version'])
-        version = output.splitlines()[0].split(' ')[2]
+        version = output.splitlines()[0].split(b' ')[2].decode()
         return [('opkg {}').format(version)]
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):


### PR DESCRIPTION
The `--all-versions` option currently fails:

```
0.19.0

ERROR: Rosdep experienced an error: a bytes-like object is required, not 'str'
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.19.0

Traceback (most recent call last):
  File "/home/chris/rosdep/src/rosdep2/main.py", line 144, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/home/chris/rosdep/src/rosdep2/main.py", line 389, in _rosdep_main
    installer_version_strings = installer.get_version_strings()
  File "/home/chris/rosdep/src/rosdep2/platforms/debian.py", line 266, in get_version_strings
    version = output.splitlines()[0].split(' ')[1]
TypeError: a bytes-like object is required, not 'str'
```

I assume this (change to `bytes`) wasn't caught during the move to Python 3.

I also checked the other implementations of `get_version_strings()` and added calls to `decode()` where necessary. Otherwise it prints out `b'1.2.3'` instead of `1.2.3`. I haven't tested nix or opkg, but it works fine for gem and apt-get.