### PR TITLE
Restrict on-push triggers to default branch.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: rosdep-ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ['*']
 
 jobs:
     build:


### PR DESCRIPTION
Follow-up to #751 to prevent duplicate runs when pushing branches.