### PR TITLE
Show rosdep-fix-permissions advice when cache read fails.

### DIFF
--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -558,8 +558,14 @@ def load_cached_sources_list(sources_cache_dir=None, verbose=False):
         if verbose:
             print('no cache index present, not loading cached sources', file=sys.stderr)
         return []
-    with open(cache_index, 'r') as f:
-        cache_data = f.read()
+    try:
+        with open(cache_index, 'r') as f:
+            cache_data = f.read()
+    except IOError as e:
+        if e.strerror == 'Permission denied':
+            raise CachePermissionError('Failed to write cache file: ' + str(e))
+        else:
+            raise
     # the loader does all the work
     model = cache_data_source_loader(sources_cache_dir, verbose=verbose)
     return parse_sources_data(cache_data, origin=cache_index, model=model)

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -563,7 +563,7 @@ def load_cached_sources_list(sources_cache_dir=None, verbose=False):
             cache_data = f.read()
     except IOError as e:
         if e.strerror == 'Permission denied':
-            raise CachePermissionError('Failed to write cache file: ' + str(e)) from e
+            raise CachePermissionError('Failed to write cache file: ' + str(e))
         else:
             raise
     # the loader does all the work

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -563,7 +563,7 @@ def load_cached_sources_list(sources_cache_dir=None, verbose=False):
             cache_data = f.read()
     except IOError as e:
         if e.strerror == 'Permission denied':
-            raise CachePermissionError('Failed to write cache file: ' + str(e))
+            raise CachePermissionError('Failed to write cache file: ' + str(e)) from e
         else:
             raise
     # the loader does all the work


### PR DESCRIPTION
By re-raising this IOError as a CachePermissionsError the advice to run
rosdep fix-permissions will be displayed instead of the general
stacktrace.

If rosdep update is run as root and then a command like rosdep resolve
is used to read from the cache rather than write to it this stacktrace
occurs as reported in #782.

### Before

```
❯ rosdep resolve python

ERROR: Rosdep experienced an error: [Errno 13] Permission denied: '/home/steven/.ros/rosdep/sources.cache/index'
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.20.0

Traceback (most recent call last):
  File "/home/steven/osrf/rosdep/src/rosdep2/main.py", line 144, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/home/steven/osrf/rosdep/src/rosdep2/main.py", line 426, in _rosdep_main
    return _rosdep_args_handler(command, parser, options, args)
  File "/home/steven/osrf/rosdep/src/rosdep2/main.py", line 448, in _rosdep_args_handler
    return command_handlers[command](args, options)
  File "/home/steven/osrf/rosdep/src/rosdep2/main.py", line 853, in command_resolve
    lookup = _get_default_RosdepLookup(options)
  File "/home/steven/osrf/rosdep/src/rosdep2/main.py", line 132, in _get_default_RosdepLookup
    sources_loader = SourcesListLoader.create_default(sources_cache_dir=options.sources_cache_dir,
  File "/home/steven/osrf/rosdep/src/rosdep2/sources_list.py", line 603, in create_default
    sources = load_cached_sources_list(sources_cache_dir=sources_cache_dir, verbose=verbose)
  File "/home/steven/osrf/rosdep/src/rosdep2/sources_list.py", line 561, in load_cached_sources_list
    with open(cache_index, 'r') as f:
PermissionError: [Errno 13] Permission denied: '/home/steven/.ros/rosdep/sources.cache/index'
```

### After

```
❯ rosdep resolve python
Failed to write cache file: [Errno 13] Permission denied: '/home/steven/.ros/rosdep/sources.cache/index'
Try running 'sudo rosdep fix-permissions'
```