### PR TITLE
List only formula in brew_detect for brew 3.0.

### DIFF
--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -184,7 +184,7 @@ def brew_detect(resolved, exec_fn=None):
     """
     if exec_fn is None:
         exec_fn = read_stdout
-    std_out = exec_fn(['brew', 'list'])
+    std_out = exec_fn(['brew', 'list', '--formula'])
     installed_formulae = std_out.split()
 
     def is_installed(r):

--- a/test/test_rosdep_osx.py
+++ b/test/test_rosdep_osx.py
@@ -91,8 +91,8 @@ def test_brew_detect():
     val = brew_detect(make_resolutions(['tinyxml']), exec_fn=m)
     assert val == [], val
     # make sure our test harness is based on the same implementation
-    m.assert_called_with(['brew', 'list'])
-    assert m.call_args_list == [call(['brew', 'list'])], m.call_args_list
+    m.assert_called_with(['brew', 'list', '--formula'])
+    assert m.call_args_list == [call(['brew', 'list', '--formula'])], m.call_args_list
 
     m = Mock()
     m.side_effect = brew_command


### PR DESCRIPTION
I think its only a cosmetic change for Mac. Fixes `Error: Calling brew list to only list formulae is disabled! Use brew list --formula instead.` warning. 