### PR TITLE
homebrew: accept keg-only packages as installed

### DIFF
--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -204,7 +204,11 @@ def brew_detect(resolved, exec_fn=None):
             pkg_info = pkg_info[0]
             linked_version = pkg_info['linked_keg']
             if not linked_version:
-                return False
+                keg_only = pkg_info['keg_only']
+                if keg_only:
+                    return True
+                else:
+                    return False
             for spec in pkg_info['installed']:
                 if spec['version'] == linked_version:
                     installed_options = spec['used_options']


### PR DESCRIPTION
fixes #764 #513 #490 (and others)

As suggested by @NikolausDemmel in his [comment](https://github.com/ros-infrastructure/rosdep/issues/490#issuecomment-276224759) :

The issue is that qt5 is keg-only and rosdep marks it as "not installed", when it in fact, it is installed yet not symlinked as mentioned by brew during (re)installation:

```
==> Reinstalling qt 
==> Pouring qt-5.15.2.catalina.bottle.tar.gz
==> Caveats
We agreed to the Qt open source license for you.
If this is unacceptable you should uninstall.

qt is keg-only, which means it was not symlinked into /usr/local,
because Qt 5 has CMake issues when linked.

If you need to have qt first in your PATH, run:
  echo 'export PATH="/usr/local/opt/qt/bin:$PATH"' >> /Users/Electroozz/.bash_profile

For compilers to find qt you may need to set:
  export LDFLAGS="-L/usr/local/opt/qt/lib"
  export CPPFLAGS="-I/usr/local/opt/qt/include"

For pkg-config to find qt you may need to set:
  export PKG_CONFIG_PATH="/usr/local/opt/qt/lib/pkgconfig"

```

As a result, Rosdep fails:
```
$ rosdep install -i --from-path src --rosdistro foxy -y
executing command [brew install qt5]
Warning: qt 5.15.2 is already installed and up-to-date.
To reinstall 5.15.2, run:
  brew reinstall qt
ERROR: the following rosdeps failed to install
  homebrew: Failed to detect successful installation of [qt5]
```

By checking if a package is keg-only when no linked keg is found, packages like Qt are accepted and rosdep finished clean.