### PR TITLE
Add support for a few RHEL clones

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ kwargs = {
     'version': '0.20.0',
     'packages': ['rosdep2', 'rosdep2.ament_packages', 'rosdep2.platforms'],
     'package_dir': {'': 'src'},
-    'install_requires': ['catkin_pkg >= 0.4.0', 'rospkg >= 1.2.7', 'rosdistro >= 0.7.5', 'PyYAML >= 3.1'],
+    'install_requires': ['catkin_pkg >= 0.4.0', 'rospkg >= 1.3.0', 'rosdistro >= 0.7.5', 'PyYAML >= 3.1'],
     'test_suite': 'nose.collector',
     'test_requires': ['mock', 'nose >= 1.0'],
     'author': 'Tully Foote, Ken Conley',

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -87,13 +87,13 @@ def register_rhel(context):
     context.set_os_version_type(OS_RHEL, lambda self: self.get_version().split('.', 1)[0])
 
 
-def register_rhel_clone(context, OS_RHEL_CLONE):
+def register_rhel_clone(context, os_rhel_clone_name):
     # Some distributions are rebuilds of RHEL and can be treated like RHEL
     # because they are versioned the same and contain the same packages.
     (os_name, os_version) = context.get_os_name_and_version()
-    if os_name == OS_RHEL_CLONE and not context.os_override:
+    if os_name == os_rhel_clone_name and not context.os_override:
         print('rosdep detected OS: [%s] aliasing it to: [%s]' %
-              (OS_RHEL_CLONE, OS_RHEL), file=sys.stderr)
+              (os_rhel_clone_name, OS_RHEL), file=sys.stderr)
         context.set_os_override(OS_RHEL, os_version.split('.', 1)[0])
 
 

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -31,7 +31,14 @@ from __future__ import print_function
 import subprocess
 import sys
 
-from rospkg.os_detect import OS_CENTOS, OS_RHEL, OS_FEDORA
+from rospkg.os_detect import (
+    OS_ALMALINUX,
+    OS_CENTOS,
+    OS_FEDORA,
+    OS_ORACLE,
+    OS_RHEL,
+    OS_ROCKY
+)
 
 from .pip import PIP_INSTALLER
 from .source import SOURCE_INSTALLER
@@ -56,7 +63,10 @@ def register_platforms(context):
     register_rhel(context)
 
     # Aliases
-    register_centos(context)
+    register_rhel_clone(context, OS_ALMALINUX)
+    register_rhel_clone(context, OS_CENTOS)
+    register_rhel_clone(context, OS_ORACLE)
+    register_rhel_clone(context, OS_ROCKY)
 
 
 def register_fedora(context):
@@ -77,13 +87,13 @@ def register_rhel(context):
     context.set_os_version_type(OS_RHEL, lambda self: self.get_version().split('.', 1)[0])
 
 
-def register_centos(context):
-    # CentOS is an alias for RHEL. If CentOS is detected and it's not set as
-    # an override force RHEL.
+def register_rhel_clone(context, OS_RHEL_CLONE):
+    # Some distributions are rebuilds of RHEL and can be treated like RHEL
+    # because they are versioned the same and contain the same packages.
     (os_name, os_version) = context.get_os_name_and_version()
-    if os_name == OS_CENTOS and not context.os_override:
+    if os_name == OS_RHEL_CLONE and not context.os_override:
         print('rosdep detected OS: [%s] aliasing it to: [%s]' %
-              (OS_CENTOS, OS_RHEL), file=sys.stderr)
+              (OS_RHEL_CLONE, OS_RHEL), file=sys.stderr)
         context.set_os_override(OS_RHEL, os_version.split('.', 1)[0])
 
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -17,8 +17,8 @@ X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [rosdep_modules]
-Depends: ca-certificates, python-rospkg-modules (>= 1.2.7), python-yaml, python-catkin-pkg-modules (>= 0.4.0), python-rosdistro-modules (>= 0.7.5), sudo
-Depends3: ca-certificates, python3-rospkg-modules (>= 1.2.7), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), sudo
+Depends: ca-certificates, python-rospkg-modules (>= 1.3.0), python-yaml, python-catkin-pkg-modules (>= 0.4.0), python-rosdistro-modules (>= 0.7.5), sudo
+Depends3: ca-certificates, python3-rospkg-modules (>= 1.3.0), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), sudo
 Conflicts: python-rosdep (<< 0.18.0), python-rosdep2
 Conflicts3: python3-rosdep (<< 0.18.0), python3-rosdep2
 Replaces: python-rosdep (<< 0.18.0)


### PR DESCRIPTION
In addition to CentOS, this change adds support for a few other RHEL clones: AlmaLinux, Oracle Linux, and Rocky Linux.