### PR TITLE
Add --no-test-deps option

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -421,7 +421,8 @@ class RosdepInstaller(object):
         self.installer_context = installer_context
         self.lookup = lookup
 
-    def get_uninstalled(self, resources, implicit=False, verbose=False):
+    def get_uninstalled(self, resources, implicit=False, verbose=False,
+                        include_test_deps=True):
         """
         Get list of system dependencies that have not been installed
         as well as a list of errors from performing the resolution.
@@ -442,7 +443,8 @@ class RosdepInstaller(object):
         # resolutions have been unique()d
         if verbose:
             print('resolving for resources [%s]' % (', '.join(resources)))
-        resolutions, errors = self.lookup.resolve_all(resources, installer_context, implicit=implicit)
+        resolutions, errors = self.lookup.resolve_all(resources, installer_context, implicit=implicit,
+                                                      include_test_deps=include_test_deps)
 
         # for each installer, figure out what is left to install
         uninstalled = []

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -306,7 +306,7 @@ class RosdepLookup(object):
         """
         return self.errors[:]
 
-    def get_rosdeps(self, resource_name, implicit=True):
+    def get_rosdeps(self, resource_name, implicit=True, include_test_deps=True):
         """
         Get rosdeps that *resource_name* (e.g. package) requires.
 
@@ -315,7 +315,7 @@ class RosdepLookup(object):
 
         :returns: list of rosdep names, ``[str]``
         """
-        return self.loader.get_rosdeps(resource_name, implicit=implicit)
+        return self.loader.get_rosdeps(resource_name, implicit=implicit, include_test_deps=include_test_deps)
 
     def get_resources_that_need(self, rosdep_name):
         """
@@ -371,7 +371,7 @@ class RosdepLookup(object):
 
         return lookup
 
-    def resolve_all(self, resources, installer_context, implicit=False):
+    def resolve_all(self, resources, installer_context, implicit=False, include_test_deps=True):
         """
         Resolve all the rosdep dependencies for *resources* using *installer_context*.
 
@@ -393,7 +393,7 @@ class RosdepLookup(object):
         # TODO: resolutions dictionary should be replaced with resolution model instead of mapping (undefined) keys.
         for resource_name in resources:
             try:
-                rosdep_keys = self.get_rosdeps(resource_name, implicit=implicit)
+                rosdep_keys = self.get_rosdeps(resource_name, implicit=implicit, include_test_deps=include_test_deps)
                 if self.verbose:
                     print('resolve_all: resource [%s] requires rosdep keys [%s]' % (resource_name, ', '.join(rosdep_keys)), file=sys.stderr)
                 rosdep_keys = prune_catkin_packages(rosdep_keys, self.verbose)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -368,6 +368,9 @@ def _rosdep_main(args):
                       help="Affects the 'update' verb. "
                            'If specified end-of-life distros are being '
                            'fetched too.')
+    parser.add_option('--no-test-deps', action='store_true',
+                      default=False,
+                      help="Ignore test dependencies.")
 
     options, args = parser.parse_args(args)
     if options.print_version or options.print_all_versions:
@@ -688,7 +691,8 @@ def command_check(lookup, packages, options):
     configure_installer_context(installer_context, options)
     installer = RosdepInstaller(installer_context, lookup)
 
-    uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=verbose)
+    uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=verbose,
+                                                    include_test_deps=not options.no_test_deps)
 
     # pretty print the result
     if [v for k, v in uninstalled if v]:
@@ -735,12 +739,12 @@ def command_install(lookup, packages, options):
         if options.verbose:
             print('reinstall is true, resolving all dependencies')
         try:
-            uninstalled, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
+            uninstalled, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive, include_test_deps=not options.no_test_deps)
         except InvalidData as e:
             print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
             return 1
     else:
-        uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose)
+        uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose, include_test_deps=not options.no_test_deps)
 
     if options.verbose:
         uninstalled_dependencies = normalize_uninstalled_to_list(uninstalled)

--- a/src/rosdep2/rospkg_loader.py
+++ b/src/rosdep2/rospkg_loader.py
@@ -130,7 +130,7 @@ class RosPkgLoader(RosdepLoader):
             self._catkin_packages_cache.update(find_catkin_paths(self._rosstack))
         return self._catkin_packages_cache
 
-    def get_rosdeps(self, resource_name, implicit=True):
+    def get_rosdeps(self, resource_name, implicit=True, include_test_deps=True):
         """
         If *resource_name* is a stack, returns an empty list.
 
@@ -140,7 +140,9 @@ class RosPkgLoader(RosdepLoader):
         if resource_name in self.get_catkin_paths():
             pkg = catkin_pkg.package.parse_package(self.get_catkin_paths()[resource_name])
             pkg.evaluate_conditions(os.environ)
-            deps = pkg.build_depends + pkg.buildtool_depends + pkg.run_depends + pkg.test_depends + pkg.buildtool_export_depends
+            deps = pkg.build_depends + pkg.buildtool_depends + pkg.run_depends + pkg.buildtool_export_depends
+            if include_test_deps:
+                deps += pkg.test_depends
             return [d.name for d in deps if d.evaluated_condition]
         elif resource_name in self.get_loadable_resources():
             rosdeps = set(self._rospack.get_rosdeps(resource_name, implicit=False))


### PR DESCRIPTION
The `--no-test-deps` option allows ignoring `test_depend` marked
dependencies. This option is useful in the case where software is deployed
using the install folder and rosdep is run on it for dependencies.

Please let me know if this looks reasonable.