### PR TITLE
Fixes for Windows

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -325,7 +325,7 @@ class PackageManagerInstaller(Installer):
         self.detect_fn = detect_fn
         self.supports_depends = supports_depends
         self.as_root = True
-        self.sudo_command = 'sudo -H' if os.geteuid() != 0 else ''
+        self.sudo_command = 'sudo -H' if hasattr(os, 'geteuid') and os.geteuid() != 0 else ''
 
     def elevate_priv(self, cmd):
         """

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -153,7 +153,10 @@ ERROR: Rosdep cannot find all required resources to answer your query
     except UsageError as e:
         print(_usage, file=sys.stderr)
         print('ERROR: %s' % (str(e)), file=sys.stderr)
-        sys.exit(os.EX_USAGE)
+        if hasattr(os, 'EX_USAGE'):
+            sys.exit(os.EX_USAGE)
+        else:
+            sys.exit()
     except RosdepInternalError as e:
         print("""
 ERROR: Rosdep experienced an internal error.
@@ -499,9 +502,9 @@ def _package_args_handler(command, parser, options, args):
     if command in ['install', 'check', 'keys'] and options.ignore_src:
         if options.verbose:
             print('Searching ROS_PACKAGE_PATH for '
-                  'sources: ' + str(os.environ['ROS_PACKAGE_PATH'].split(':')))
+                  'sources: ' + str(os.environ['ROS_PACKAGE_PATH'].split(os.pathsep)))
         ws_pkgs = get_workspace_packages()
-        for path in os.environ['ROS_PACKAGE_PATH'].split(':'):
+        for path in os.environ['ROS_PACKAGE_PATH'].split(os.pathsep):
             path = os.path.abspath(path.strip())
             if os.path.exists(path):
                 pkgs = find_catkin_packages_in(path, options.verbose)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -156,7 +156,7 @@ ERROR: Rosdep cannot find all required resources to answer your query
         if hasattr(os, 'EX_USAGE'):
             sys.exit(os.EX_USAGE)
         else:
-            sys.exit()
+            sys.exit(64)  # EX_USAGE is not available on Windows; EX_USAGE is 64 on Unix
     except RosdepInternalError as e:
         print("""
 ERROR: Rosdep experienced an internal error.

--- a/src/rosdep2/platforms/source.py
+++ b/src/rosdep2/platforms/source.py
@@ -302,6 +302,7 @@ def install_source(resolved):
             rd_debug('Extracting tarball')
             tarf = tarfile.open(filename)
             tarf.extractall(tempdir)
+            tarf.close()
         else:
             rd_debug('Bypassing tarball extraction as it is a dmg')
         rd_debug('Running installation script')

--- a/src/rosdep2/shell_utils.py
+++ b/src/rosdep2/shell_utils.py
@@ -84,7 +84,8 @@ def create_tempfile_from_string_and_execute(string_script, path=None, exec_fn=No
 
     result = 1
     try:
-        fh = tempfile.NamedTemporaryFile('w', delete=False)
+        script_ext = '.bat' if os.name == 'nt' else ''
+        fh = tempfile.NamedTemporaryFile('w', suffix=script_ext, delete=False)
         fh.write(string_script)
         fh.close()
         rd_debug('Executing script below with cwd=%s\n{{{\n%s\n}}}\n' % (path, string_script))


### PR DESCRIPTION
This PR contains a minimal set of changes from https://github.com/ros-infrastructure/rosdep/pull/661 to get the RoboStack installer (https://github.com/ros-infrastructure/rosdep/pull/810) to work on Windows.

@nuclearsandwich already had a look at https://github.com/ros-infrastructure/rosdep/pull/661 and the last comment was to rework the Azure pipeline to use GitHub actions instead; in this PR I'm taking a more minimal approach and only pull in easy-to-review changes without touching tests etc. which we don't need for our RoboStack use-case.

The contents of the PR are already used within the conda-forge build of rosdep (see https://github.com/conda-forge/rosdep-feedstock). We confirmed that Windows works in our moveit PR to add cross-platform CI (https://github.com/ros-planning/moveit/pull/2604) which makes use of rosdep.

/cc @wolfv @traversaro