### PR TITLE
Fix version string for npm by decoding bytes

### DIFF
--- a/src/rosdep2/platforms/npm.py
+++ b/src/rosdep2/platforms/npm.py
@@ -83,7 +83,7 @@ class NpmInstaller(PackageManagerInstaller):
         return ret_list
 
     def get_version_strings(self):
-        npm_version = subprocess.check_output(['npm', '--version']).strip()
+        npm_version = subprocess.check_output(['npm', '--version']).strip().decode()
         return ['npm {}'.format(npm_version)]
 
     def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):


### PR DESCRIPTION
Before:

```
$ rosdep --all-versions
0.20.1

Versions of installers:
  apt-get 2.0.5
  pip 21.0.1
  setuptools 53.0.0
  gem 3.1.2
  npm b'6.13.4'
```

After:

```
$ rosdep --all-versions
0.20.1

Versions of installers:
  apt-get 2.0.5
  pip 21.0.1
  setuptools 53.0.0
  gem 3.1.2
  npm 6.13.4
```

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>