### PR TITLE
Print "not installed" for uninstalled installers with --all-versions

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -392,6 +392,9 @@ def _rosdep_main(args):
             except NotImplementedError:
                 version_strings.append('{} unknown'.format(key))
                 continue
+            except FileNotFoundError:
+                version_strings.append('{} not installed'.format(key))
+                continue
         if version_strings:
             print()
             print('Versions of installers:')

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -33,6 +33,7 @@ Command-line interface to rosdep library
 
 from __future__ import print_function
 
+import errno
 import os
 import sys
 import traceback
@@ -392,7 +393,9 @@ def _rosdep_main(args):
             except NotImplementedError:
                 version_strings.append('{} unknown'.format(key))
                 continue
-            except FileNotFoundError:
+            except EnvironmentError as e:
+                if e.errno != errno.ENOENT:
+                    raise
                 version_strings.append('{} not installed'.format(key))
                 continue
         if version_strings:


### PR DESCRIPTION
Fixes #813

Instead of raising a `FileNotFoundError` error when a given executable isn't found/installed, just print "not installed":

```
$ rosdep --all-versions
0.20.1

Versions of installers:
  apt-get 2.0.4
  pip 20.0.2
  setuptools 45.2.0
  gem not installed
  npm not installed
```

I thought about catching the most generic error that `subprocess.check_output()` can raise, but this might be enough.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>