### PR TITLE
Correctly detect when pip is not available

### DIFF
--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -70,8 +70,9 @@ def get_pip_command():
 
 def is_cmd_available(cmd):
     try:
-        subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-        return True
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        _ = proc.communicate()
+        return 0 == proc.returncode
     except OSError:
         return False
 


### PR DESCRIPTION
Relates to #821

The current implementation of `is_cmd_available()` for `pip` fails to detect when it's not available and leads to a weird verbose output and some generic error message:

```
$ rosdep install --rosdistro rolling --from-paths src/ 
/usr/bin/python3: No module named pip
/usr/bin/python3: No module named pip
executing command [python3 -m pip install -U bokeh]
/usr/bin/python3: No module named pip
ERROR: the following rosdeps failed to install
  pip: command [python3 -m pip install -U bokeh] failed
```

This is with a workspace that has a single `package.xml` file with a single `pip` dependency: `<depend>python3-bokeh-pip</depend>`.

It does correctly detect when the `pip`/`pip2`/`pip3` command isn't available, but it then checks `pythonN -m pip` and returns `True` if the call to `subprocess.Popen().communicate()` doesn't raise any error. The problem is that it never does raise any error:

```
>>> import subprocess
>>> subprocess.Popen(['python3', '-m', 'pip'], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
(b'', b'/usr/bin/python3: No module named pip\n')
```

The output is clear, but we can also fix this by checking the return code:

```
$ python3 -m abcdefjahuqhbiujhrfdbhwjihbujfd
/usr/bin/python3: No module named abcdefjahuqhbiujhrfdbhwjihbujfd
$ echo $?
1
```

This results in this way clearer output:

```
$ rosdep install --rosdistro rolling --from-paths src/
ERROR: the following rosdeps failed to install
  pip: pip is not installed
```

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>