### PR TITLE
Correctly detect when gem is not available

### DIFF
--- a/src/rosdep2/platforms/gem.py
+++ b/src/rosdep2/platforms/gem.py
@@ -58,6 +58,9 @@ def gem_detect(pkgs, exec_fn=None):
 
     :param exec_fn: function to execute Popen and read stdout (for testing)
     """
+    if not is_gem_installed():
+        return []
+
     if exec_fn is None:
         exec_fn = read_stdout
     pkg_list = exec_fn(['gem', 'list']).split('\n')


### PR DESCRIPTION
Relates to #821

Currently, when trying to install dependencies from the `gem` installer when `gem` isn't installed, we get this:

```
$ rosdep install --rosdistro rolling --from-paths src/test_pkg_gem

ERROR: Rosdep experienced an internal error.
Please go to the rosdep page [1] and file a bug report with the message below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.21.0

Bad installer [gem]: [Errno 2] No such file or directory: 'gem'

```

This is with a workspace that has a single `package.xml` file with a single `gem` dependency: `<depend>metaruby</depend>`. The error message isn't really clear; users shouldn't really be asked to open an issue in this case.

This fix is just doing what the `pip` installer does: if `gem` isn't installed, then none of the resolved packages are currently installed on the system, so we can simply return right away. Later on, when we try to install them, we finally get to raise an error saying that `gem` isn't installed (in `GemInstaller.get_install_command()`). We get this:

```
$ rosdep install --rosdistro rolling --from-paths src/test_pkg_gem
ERROR: the following rosdeps failed to install
  gem: gem is not installed
```

This is the same as #822.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>