### PR TITLE
Drop support for EOL Ubuntu distros

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,17 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-18.04, macos-latest]
+          os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
           python: [2.7, 3.6, 3.7, 3.8, 3.9]
           exclude:
+          - os: ubuntu-20.04
+            python: 2.7
+          - os: ubuntu-20.04
+            python: 3.5
+          - os: ubuntu-20.04
+            python: 3.6
+          - os: ubuntu-20.04
+            python: 3.7
           - os: macos-latest
             python: 3.6
       name: rosdep tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,21 +10,9 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-16.04, ubuntu-18.04, macos-latest]
-          python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+          os: [ubuntu-18.04, macos-latest]
+          python: [2.7, 3.6, 3.7, 3.8, 3.9]
           exclude:
-          - os: ubuntu-16.04
-            python: 3.6
-          - os: ubuntu-16.04
-            python: 3.7
-          - os: ubuntu-16.04
-            python: 3.8
-          - os: ubuntu-16.04
-            python: 3.9  
-          - os: ubuntu-18.04
-            python: 3.5
-          - os: macos-latest
-            python: 3.5
           - os: macos-latest
             python: 3.6
       name: rosdep tests

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -10,8 +10,8 @@ Depends3: python3-rosdep-modules (>= 0.21.0)
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic jessie stretch buster
+Suite3: bionic focal jessie stretch buster
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
@@ -24,8 +24,8 @@ Conflicts3: python3-rosdep (<< 0.18.0), python3-rosdep2
 Replaces: python-rosdep (<< 0.18.0)
 Replaces3: python3-rosdep (<< 0.18.0)
 Copyright-File: LICENSE
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic jessie stretch buster
+Suite3: bionic focal jessie stretch buster
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
https://wiki.ubuntu.com/Releases#List_of_releases

- Xenial:  Apr 2021
- Yakkety: Jul 2017
- Zesty:   Jan 2019
- Artful:  Jul 2018
- Cosmic:  Oct 2018
- Disco:   Apr 2019
- Eoan:    Oct 2019