### PR TITLE
Update target package for tests

### DIFF
--- a/test/sources_cache/f6f4ef95664e373cd4754501337fa217f5b55d91
+++ b/test/sources_cache/f6f4ef95664e373cd4754501337fa217f5b55d91
@@ -11,14 +11,14 @@ paramiko:
 testpython:
   arch: python
   cygwin: python
-  debian: python-dev
-  fedora: python-devel
+  debian: python3-dev
+  fedora: python3-devel
   freebsd: python
   gentoo: python
   opensuse: python-devel
-  rhel: python-devel
+  rhel: python3-devel
   slackware: python
-  ubuntu: python-dev
+  ubuntu: python3-dev
   osx:
     homebrew:
       packages: []

--- a/test/test_rosdep_main.py
+++ b/test/test_rosdep_main.py
@@ -172,8 +172,8 @@ class TestRosdepMain(unittest.TestCase):
             if cmd[0] == 'apt-cache' and cmd[1] == 'showpkg':
                 result = ''
             elif cmd[0] == 'dpkg-query':
-                if cmd[-1] == 'python-dev':
-                    result = '\'python-dev install ok installed\n\''
+                if cmd[-1] == 'python3-dev':
+                    result = '\'python3-dev install ok installed\n\''
                 else:
                     result = '\n'.join(["dpkg-query: no packages found matching %s" % f for f in cmd[3:]])
 

--- a/test/tree/ros/rosdep.yaml
+++ b/test/tree/ros/rosdep.yaml
@@ -6,12 +6,12 @@ testtinyxml:
       uri: 'http://kforge.ros.org/rosrelease/viewvc/sourcedeps/tinyxml/tinyxml-2.6.2-1.rdmanifest'
       md5sum: 13760e61e08c9004493c302a16966c42
 testpython:
-  ubuntu: python-dev
-  debian: python-dev
+  ubuntu: python3-dev
+  debian: python3-dev
   arch: python
   opensuse: python-devel
-  fedora: python-devel
-  rhel: python-devel
+  fedora: python3-devel
+  rhel: python3-devel
   macports: python26 python_select
   gentoo: python
   cygwin: python


### PR DESCRIPTION
These tests currently look for python-dev, which is no longer a package in Ubuntu Focal. This change updates the target package for Ubuntu to look for Python 3, and updates Debian, Fedora, and RHEL to do the same.

Aside: it's unfortunate that the system environment is leaking into the test like this, but right now my priority is to get the tests passing again.

This is needed for https://github.com/ros-infrastructure/rosdep/pull/829#discussion_r712316562