### PR TITLE
Add support for --sources-cache-dir to update verb

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -651,7 +651,7 @@ def command_update(options):
         return 1
     try:
         print('reading in sources list data from %s' % (sources_list_dir))
-        sources_cache_dir = get_sources_cache_dir()
+        sources_cache_dir = options.sources_cache_dir
         try:
             if os.geteuid() == 0:
                 print("Warning: running 'rosdep update' as root is not recommended.", file=sys.stderr)
@@ -659,7 +659,9 @@ def command_update(options):
         except AttributeError:
             # nothing we wanna do under Windows
             pass
-        update_sources_list(success_handler=update_success_handler,
+        update_sources_list(sources_list_dir=sources_list_dir,
+                            sources_cache_dir=sources_cache_dir,
+                            success_handler=update_success_handler,
                             error_handler=update_error_handler,
                             skip_eol_distros=not options.include_eol_distros,
                             ros_distro=options.ros_distro)


### PR DESCRIPTION
From what I can tell, support for this option was only implemented for the `install` verb.

From `rosdep update --help`:
```
  ...
  -c SOURCES_CACHE_DIR, --sources-cache-dir=SOURCES_CACHE_DIR
                        Override ~/.ros/rosdep/sources.cache
  ...
```