### PR TITLE
Detect Alpine package name with alias

### DIFF
--- a/src/rosdep2/platforms/alpine.py
+++ b/src/rosdep2/platforms/alpine.py
@@ -87,7 +87,7 @@ def apk_detect(pkgs, exec_fn=read_stdout):
         elif line == '':
             reading = False
         elif reading:
-            replaced_packages.append(line)
+            replaced_packages.append(line.strip())
 
     return origin_packages + replaced_packages
 

--- a/src/rosdep2/platforms/alpine.py
+++ b/src/rosdep2/platforms/alpine.py
@@ -61,11 +61,35 @@ def apk_detect(pkgs, exec_fn=read_stdout):
     if not pkgs:
         return []
 
-    cmd = ['apk', 'info', '--installed']
-    cmd.extend(pkgs)
-    std_out = exec_fn(cmd)
+    # Get installed package names:
+    cmd_installed = ['apk', 'info', '--installed']
+    cmd_installed.extend(pkgs)
+    origin_packages = exec_fn(cmd_installed).splitlines()
 
-    return std_out.splitlines()
+    # Resolve alias names of replaced packages.
+    cmd_replaces = ['apk', 'info', '--installed', '--replaces']
+    cmd_replaces.extend(pkgs)
+    # This command will respond like:
+    #
+    #    $ apk info --installed --replaces boost-atomic boost-filesystem
+    #    boost1.76-atomic-1.76.0-r0 replaces:
+    #    boost-atomic
+    #
+    #    boost1.76-filesystem-1.76.0-r0 replaces:
+    #    boost-filesystem
+    #
+    #    $
+    replaced_packages = []
+    reading = False
+    for line in exec_fn(cmd_replaces).splitlines():
+        if line.endswith(' replaces:'):
+            reading = True
+        elif line == '':
+            reading = False
+        elif reading:
+            replaced_packages.append(line)
+
+    return origin_packages + replaced_packages
 
 
 class ApkInstaller(PackageManagerInstaller):

--- a/test/test_rosdep_alpine.py
+++ b/test/test_rosdep_alpine.py
@@ -30,9 +30,9 @@
 import os
 import traceback
 try:
-    from unittest.mock import Mock, patch
+    from unittest.mock import Mock, call, patch
 except ImportError:
-    from mock import Mock, patch
+    from mock import Mock, call, patch
 
 import rospkg.os_detect
 

--- a/test/test_rosdep_alpine.py
+++ b/test/test_rosdep_alpine.py
@@ -29,7 +29,7 @@
 
 import os
 import traceback
-from mock import Mock, patch
+from mock import Mock, call, patch
 
 import rospkg.os_detect
 
@@ -52,13 +52,42 @@ def test_apk_detect():
     expected = []
     val = apk_detect(['a'], exec_fn=m)
     assert val == expected, 'Result was: %s' % val
-    m.assert_called_with(['apk', 'info', '--installed', 'a'])
+    m.assert_has_calls([
+        call(['apk', 'info', '--installed', 'a']),
+        call(['apk', 'info', '--installed', '--replaces', 'a']),
+    ])
 
-    m = Mock(return_value='\n'.join(['a', 'b']))
+    m = Mock(side_effect=[
+        '\n'.join(['a', 'b']),
+        '',
+    ])
     expected = ['a', 'b']
     val = apk_detect(['a', 'b'], exec_fn=m)
     assert val == expected, 'Result was: %s' % val
-    m.assert_called_with(['apk', 'info', '--installed', 'a', 'b'])
+    m.assert_has_calls([
+        call(['apk', 'info', '--installed', 'a', 'b']),
+        call(['apk', 'info', '--installed', '--replaces', 'a', 'b']),
+    ])
+
+    # Packages installed by alias names should be resolved.
+    m = Mock(side_effect=[
+        '\n'.join(['origin-pkg1', 'origin-pkg2']),
+        '\n'.join([
+            'origin-pkg1=0.0.0-r0 replaces:',
+            'alias-pkg1',
+            '',
+            'origin-pkg2=1.1.1-r1 replaces:',
+            'alias-pkg2',
+            '',
+        ]),
+    ])
+    expected = ['origin-pkg1', 'origin-pkg2', 'alias-pkg1', 'alias-pkg2']
+    val = apk_detect(['alias-pkg1', 'alias-pkg2'], exec_fn=m)
+    assert val == expected, 'Result was: %s' % val
+    m.assert_has_calls([
+        call(['apk', 'info', '--installed', 'alias-pkg1', 'alias-pkg2']),
+        call(['apk', 'info', '--installed', '--replaces', 'alias-pkg1', 'alias-pkg2']),
+    ])
 
 
 def test_ApkInstaller():


### PR DESCRIPTION
Address https://github.com/ros/rosdistro/pull/31565#issuecomment-1000664152

On the recent version of Alpine including `edge`, [package `boost` does not exist](https://pkgs.alpinelinux.org/packages?name=boost&branch=v3.15&arch=x86_64) but [`boost1.77` package provides boost with alias name of `boost`](https://git.alpinelinux.org/aports/tree/main/boost1.77/APKBUILD#n71).
This PR fixes package detection when the package is installed by alias name.

Local test using docker:
```shell
$ docker run -it --rm -v $(pwd):/work/rosdep alpine:3.15
$ apk add py3-pip
$ python3 -m pip install /work/rosdep
$ rosdep init
$ sed -i -e 's|ros/rosdistro/master|alpine-ros/rosdistro/alpine-custom-apk|' /etc/ros/rosdep/sources.list.d/20-default.list
$ rosdep update
$ mkdir -p /work/tmp
$ cat << EOF > /work/tmp/package.xml
<package format="2">
  <name>dummy</name>
  <version>0.0.0</version>
  <description>foo</description>
  <license>dummy</license>
  <maintainer email="dummy@dummy.dummy">dummy</maintainer>
  <depend>libboost-atomic</depend>
</package>
EOF
$ rosdep install --from-path /work/tmp -y
WARNING: ROS_PYTHON_VERSION is unset. Defaulting to 3
executing command [apk add boost]
(1/34) Installing boost1.77-atomic (1.77.0-r1)
...
(34/34) Installing boost1.77 (1.77.0-r1)
Executing busybox-1.34.1-r3.trigger
OK: 85 MiB in 87 packages
#All required rosdeps installed successfully
```