### PR TITLE
split pip commands to support args

### DIFF
--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -150,4 +150,5 @@ class PipInstaller(PackageManagerInstaller):
             cmd.append('-q')
         if reinstall:
             cmd.append('-I')
-        return [self.elevate_priv(cmd + [p]) for p in packages]
+
+        return [self.elevate_priv(cmd + p.split()) for p in packages]


### PR DESCRIPTION
This addresses the use-case where custom `pip` args need to be passed from a rosdep definition. This could be applied to other installers but is just done here for `pip`.

For example, a sample `rosdep.yaml` definition given below can be correctly processed and executed, whereas the current implementation will cause an error related to trying to pass 
`['sudo', '-H', 'pip2', 'install', '-U', 'torch-scatter -f https://data.pyg.org/whl/torch-1.8.1+cu111.html']`
to pip via subprocess. The correct subprocess call should be 
`['sudo', '-H', 'pip2', 'install', '-U', 'torch-scatter', '-f', 'https://data.pyg.org/whl/torch-1.8.1+cu111.html']`, 
which is achieved by this patch.
 

``` yaml
torch_scatter:
  ubuntu:
    bionic:
      pip: ["torch-scatter -f https://data.pyg.org/whl/torch-1.8.1+cu111.html"]
```

The error when trying to run this definition through the current implementation is :
```
executing command [sudo -H pip2 install -U torch-scatter -f https://data.pyg.org/whl/torch-1.8.1+cu111.html]
Invalid requirement: 'torch-scatter -f https://data.pyg.org/whl/torch-1.8.1+cu111.html'
It looks like a path. Does it exist ?    
```