### PR TITLE
Use unittest.mock where possible

### DIFF
--- a/test/test_rosdep_alpine.py
+++ b/test/test_rosdep_alpine.py
@@ -29,7 +29,10 @@
 
 import os
 import traceback
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 import rospkg.os_detect
 

--- a/test/test_rosdep_arch.py
+++ b/test/test_rosdep_arch.py
@@ -29,7 +29,10 @@
 
 import os
 import traceback
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 
 def get_test_dir():

--- a/test/test_rosdep_cygwin.py
+++ b/test/test_rosdep_cygwin.py
@@ -29,7 +29,10 @@
 
 import os
 import traceback
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 
 def get_test_dir():

--- a/test/test_rosdep_debian.py
+++ b/test/test_rosdep_debian.py
@@ -29,7 +29,10 @@
 
 import os
 import traceback
-from mock import Mock, patch, call
+try:
+    from unittest.mock import Mock, patch, call
+except ImportError:
+    from mock import Mock, patch, call
 
 
 def get_test_dir():

--- a/test/test_rosdep_freebsd.py
+++ b/test/test_rosdep_freebsd.py
@@ -30,7 +30,10 @@
 
 import os
 import traceback
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 
 
 def get_test_dir():

--- a/test/test_rosdep_gem.py
+++ b/test/test_rosdep_gem.py
@@ -31,7 +31,10 @@
 
 import os
 import traceback
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 
 def get_test_dir():

--- a/test/test_rosdep_gentoo.py
+++ b/test/test_rosdep_gentoo.py
@@ -29,7 +29,10 @@
 
 import os
 import traceback
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 import rospkg.os_detect
 

--- a/test/test_rosdep_installers.py
+++ b/test/test_rosdep_installers.py
@@ -28,7 +28,10 @@
 from __future__ import print_function
 
 from contextlib import contextmanager
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 import os
 import sys
 try:
@@ -117,7 +120,6 @@ def test_InstallerContext_os_version_and_name():
     context.set_os_override(*val)
     assert val == context.get_os_name_and_version()
 
-    from mock import Mock
     os_detect_mock = Mock(spec=OsDetect)
     os_detect_mock.get_name.return_value = 'fakeos'
     os_detect_mock.get_version.return_value = 'fakeos-version'
@@ -559,7 +561,6 @@ def test_RosdepInstaller_get_uninstalled_unconfigured():
         assert 'apt' in str(e)
 
     # annoying mock to test generally impossible error condition
-    from mock import Mock
     lookup = Mock(spec=RosdepLookup)
     lookup.resolve_all.return_value = ([('bad-key', ['stuff'])], [])
 

--- a/test/test_rosdep_loader.py
+++ b/test/test_rosdep_loader.py
@@ -25,7 +25,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 
 def test_RosdepLoader():

--- a/test/test_rosdep_main.py
+++ b/test/test_rosdep_main.py
@@ -38,8 +38,10 @@ import rospkg.os_detect
 
 import unittest
 
-from mock import patch
-from mock import DEFAULT
+try:
+    from unittest.mock import DEFAULT, patch
+except ImportError:
+    from mock import DEFAULT, patch
 
 from rosdep2 import main
 from rosdep2.ament_packages import AMENT_PREFIX_PATH_ENV_VAR

--- a/test/test_rosdep_npm.py
+++ b/test/test_rosdep_npm.py
@@ -31,7 +31,10 @@
 
 import os
 import traceback
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 
 def get_test_dir():

--- a/test/test_rosdep_opensuse.py
+++ b/test/test_rosdep_opensuse.py
@@ -29,7 +29,10 @@
 
 import os
 import traceback
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 
 def get_test_dir():

--- a/test/test_rosdep_osx.py
+++ b/test/test_rosdep_osx.py
@@ -32,9 +32,10 @@
 import os
 import traceback
 
-from mock import call
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import call, Mock, patch
+except ImportError:
+    from mock import call, Mock, patch
 
 
 def get_test_dir():

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -30,7 +30,10 @@
 import os
 import sys
 import traceback
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 
 def get_test_dir():

--- a/test/test_rosdep_redhat.py
+++ b/test/test_rosdep_redhat.py
@@ -29,7 +29,10 @@
 
 import os
 import traceback
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 
 
 def get_test_dir():

--- a/test/test_rosdep_rospkg_loader.py
+++ b/test/test_rosdep_rospkg_loader.py
@@ -30,7 +30,10 @@
 import os
 import yaml
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from rospkg import RosPack, RosStack
 
 

--- a/test/test_rosdep_slackware.py
+++ b/test/test_rosdep_slackware.py
@@ -29,7 +29,10 @@
 
 import os
 import traceback
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 import rospkg.os_detect
 


### PR DESCRIPTION
The 'unittest.mock' module has been present since Python 3.3, and some platforms are now dropping the 'mock' backport package.