### PR TITLE
If Manjaro is detected override to Arch Linux

### DIFF
--- a/src/rosdep2/platforms/arch.py
+++ b/src/rosdep2/platforms/arch.py
@@ -28,8 +28,9 @@
 # Author Tully Foote/tfoote@willowgarage.com
 
 import subprocess
+import sys
 
-from rospkg.os_detect import OS_ARCH
+from rospkg.os_detect import OS_ARCH, OS_MANJARO
 
 from ..installers import PackageManagerInstaller
 from .source import SOURCE_INSTALLER
@@ -45,6 +46,17 @@ def register_platforms(context):
     context.add_os_installer_key(OS_ARCH, SOURCE_INSTALLER)
     context.add_os_installer_key(OS_ARCH, PACMAN_INSTALLER)
     context.set_default_os_installer_key(OS_ARCH, lambda self: PACMAN_INSTALLER)
+
+    register_manjaro(context)
+
+
+def register_manjaro(context):
+    # Manjaro uses the same packages as Arch Linux. Override to Arch if detected
+    (os_name, os_version) = context.get_os_name_and_version()
+    if os_name == OS_MANJARO and not context.os_override:
+        print('rosdep detected OS: [%s] aliasing it to: [%s]' %
+              (OS_MANJARO, OS_ARCH), file=sys.stderr)
+        context.set_os_override(OS_ARCH, context.os_detect.get_codename())
 
 
 def pacman_detect_single(p):

--- a/src/rosdep2/platforms/arch.py
+++ b/src/rosdep2/platforms/arch.py
@@ -27,6 +27,7 @@
 
 # Author Tully Foote/tfoote@willowgarage.com
 
+from __future__ import print_function
 import subprocess
 import sys
 


### PR DESCRIPTION
I am trying to bring up a ros core install on my Manjaro machine and have been adding rosdep keys to `arch`. Manjaro uses the same packages as Arch Linux, only delaying updates a little while before pushing to manjaro. I have been using rosdep's override argument to install the deps, but making this PR seemed more appropriate.

There are no `manjaro` keys in rosdistro/rosdep/*.yml