### PR TITLE
Alias Raspbian to Debian

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ kwargs = {
     'version': '0.21.0',
     'packages': ['rosdep2', 'rosdep2.ament_packages', 'rosdep2.platforms'],
     'package_dir': {'': 'src'},
-    'install_requires': ['catkin_pkg >= 0.4.0', 'rospkg >= 1.3.0', 'rosdistro >= 0.7.5', 'PyYAML >= 3.1'],
+    'install_requires': ['catkin_pkg >= 0.4.0', 'rospkg >= 1.4.0', 'rosdistro >= 0.7.5', 'PyYAML >= 3.1'],
     'test_suite': 'nose.collector',
     'test_requires': ['mock', 'nose >= 1.0'],
     'author': 'Tully Foote, Ken Conley',

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -38,6 +38,7 @@ from rospkg.os_detect import (
     OS_ELEMENTARY,
     OS_MX,
     OS_POP,
+    OS_RASPBIAN,
     OS_ZORIN,
     OsDetect,
     read_os_release
@@ -66,6 +67,7 @@ def register_platforms(context):
     register_linaro(context)
     register_mx(context)
     register_pop(context)
+    register_raspbian(context)
     register_zorin(context)
 
 
@@ -119,6 +121,16 @@ def register_pop(context):
         print('rosdep detected OS: [%s] aliasing it to: [%s]' %
               (OS_POP, OS_UBUNTU), file=sys.stderr)
         context.set_os_override(OS_UBUNTU, context.os_detect.get_codename())
+
+
+def register_raspbian(context):
+    # Raspbian is an alias for Debian. If Raspbian is detected and it's
+    # not set as an override force Debian.
+    (os_name, os_version) = context.get_os_name_and_version()
+    if os_name == OS_RASPBIAN and not context.os_override:
+        print('rosdep detected OS: [%s] aliasing it to: [%s]' %
+              (OS_RASPBIAN, OS_DEBIAN), file=sys.stderr)
+        context.set_os_override(OS_DEBIAN, context.os_detect.get_codename())
 
 
 def register_zorin(context):

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -17,8 +17,8 @@ X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [rosdep_modules]
-Depends: ca-certificates, python-rospkg-modules (>= 1.3.0), python-yaml, python-catkin-pkg-modules (>= 0.4.0), python-rosdistro-modules (>= 0.7.5), sudo
-Depends3: ca-certificates, python3-rospkg-modules (>= 1.3.0), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), sudo
+Depends: ca-certificates, python-rospkg-modules (>= 1.4.0), python-yaml, python-catkin-pkg-modules (>= 0.4.0), python-rosdistro-modules (>= 0.7.5), sudo
+Depends3: ca-certificates, python3-rospkg-modules (>= 1.4.0), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), sudo
 Conflicts: python-rosdep (<< 0.18.0), python-rosdep2
 Conflicts3: python3-rosdep (<< 0.18.0), python3-rosdep2
 Replaces: python-rosdep (<< 0.18.0)


### PR DESCRIPTION
Debian is the upstream source for Debian packages.

`OS_RASPBIAN` was added to rospkg in ros-infrastructure/rospkg#244 and was released in 1.4.0.

Note that there aren't any detectors behind `OS_RASPBIAN` right now. It will be a breaking change for rospkg to switch detecting Raspbian as `debian` and start detecting as `raspbian` instead, and this change prepares for that eventuality.