### PR TITLE
Bump minimum Python 3 version in stdeb to 3.6

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -13,7 +13,7 @@ Copyright-File: LICENSE
 Suite: bionic buster
 Suite3: bionic focal jammy buster bullseye
 Python2-Depends-Name: python
-X-Python3-Version: >= 3.4
+X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [rosdep_modules]
@@ -27,5 +27,5 @@ Copyright-File: LICENSE
 Suite: bionic buster
 Suite3: bionic focal jammy buster bullseye
 Python2-Depends-Name: python
-X-Python3-Version: >= 3.4
+X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Python 3.6 is the Python 3 version packaged for Bionic, and it is the minimum version we're running CI for.