### PR TITLE
Declare test dependencies in [test] extra

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,7 @@ jobs:
           python-version: ${{matrix.python}}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
-          python -m pip install -e .
-          python -m pip install pytest pytest-cov flake8 flake8-comprehensions mock codecov
+          python -m pip install -U -e .[test] codecov pytest-cov
       - name: Run tests
         run: |
           python -m pytest test --cov

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,14 @@ kwargs = {
     'packages': ['rosdep2', 'rosdep2.ament_packages', 'rosdep2.platforms'],
     'package_dir': {'': 'src'},
     'install_requires': ['catkin_pkg >= 0.4.0', 'rospkg >= 1.4.0', 'rosdistro >= 0.7.5', 'PyYAML >= 3.1'],
-    'test_requires': ['mock', 'pytest'],
+    'extras_require': {
+        'test': [
+            'flake8',
+            'flake8-comprehensions',
+            "mock; python_version < '3.3'",
+            'pytest',
+        ],
+    },
     'author': 'Tully Foote, Ken Conley',
     'author_email': 'tfoote@osrfoundation.org',
     'maintainer': 'ROS Infrastructure Team',


### PR DESCRIPTION
Formally declaring the test dependencies somewhere is a good idea, and allows tools like `colcon` to discover them.

['extras_require']['test'] is where we put these dependencies in colcon itself, but there doesn't appear to be a strong consensus among the packaging community regarding where to list these, and many options aren't compatible with python 2, which is still supported in this package. This option seems to meet all of our needs.

Also make the 'mock' dependency conditional, now that this package supports using unittest.mock.