### PR TITLE
Ignore rosdep's own deprecations when running rosdep tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [tool:pytest]
+filterwarnings =
+    ignore:deprecated.( use rosdistro instead| see REP137 and rosdistro):UserWarning:rosdep2
 junit_suite_name = rosdep
 
 [coverage:run]


### PR DESCRIPTION
It isn't useful to see these warnings when running rosdep's tests.