### PR TITLE
Run tests against Python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,19 +4,18 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: ['*']
 
 jobs:
     build:
       strategy:
         matrix:
           os: [ubuntu-latest, macos-latest]
-          python: [3.7, 3.8, 3.9]
+          python: ['3.7', '3.8', '3.9', '3.10']
           include:
           - os: ubuntu-18.04
-            python: 2.7
+            python: '2.7'
           - os: ubuntu-18.04
-            python: 3.6
+            python: '3.6'
       name: rosdep tests
       runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Also drop PR branch wildcard to align with other ROS infrastructure CI workflows.