### PR TITLE
Handle pip package versions like pip does

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ elif 'SKIP_PYTHON_SCRIPTS' in os.environ:
     kwargs['name'] += '_modules'
     kwargs['entry_points'] = {}
 else:
-    kwargs['install_requires'] += ['catkin_pkg >= 0.4.0', 'rospkg >= 1.4.0', 'rosdistro >= 0.7.5']
+    kwargs['install_requires'] += ['catkin_pkg >= 0.4.0', 'rospkg >= 1.4.0', 'rosdistro >= 0.7.5', 'packaging']
 
 setup(**kwargs)

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -102,6 +102,10 @@ def pip_detect(pkgs, exec_fn=None):
 
     for pkg in pkg_list:
         pkg_row = pkg.split('==')
+        
+        # Account for some unusual instances of === instead of ==
+        pkg_row[1] = pkg_row[1].strip('=')
+
         version_list.append((pkg_row[0], Version(pkg_row[1])))
 
     for pkg in pkgs:


### PR DESCRIPTION
With most ROS-supported operating systems and their default package managers, major version changes will usually not be automatically introduced. This avoids major incompatibilities being introduced within a given, supported operating system version for packages installed through the default package manager. As PyPi retains Python modules which are not tied to operating system versions, major, breaking changes can be introduced unexpectedly. Therefore, there exists a need for `rosdep` to be able to handle version management of `pip`-installed modules. This PR introduces version checking to `rosdep` when verifying pip package installation.

Since `rosdep` passes package requirements directly from a keys YAML file to `pip` without modification, the installation of packages with version requirements was already possible. However, if a package with a version requirement was specified and installed, `rosdep` did not understand how to verify that the version requirement had been met. This PR adds this functionality.

Since this PR uses the [`packaging`](https://pypi.org/project/packaging/) module, it automatically complies with https://peps.python.org/pep-0440/ and https://peps.python.org/pep-0508/.

Covers the version-checking requirement (but not the extras-checkig one) of #900.