### PR TITLE
Fix handling of duplicate dependencies

### DIFF
--- a/src/rosdep2/dependency_graph.py
+++ b/src/rosdep2/dependency_graph.py
@@ -27,7 +27,7 @@
 
 # Author William Woodall/wjwwood@gmail.com
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
 
 class Resolution(dict):
@@ -130,7 +130,14 @@ class DependencyGraph(defaultdict):
                 squashed_result.append((installer_key, []))
                 previous_installer_key = installer_key
             squashed_result[-1][1].extend(resolved)
-        return squashed_result
+        # Remove duplicate keys
+        deduplicated_result = []
+        for installer_key, install_keys in squashed_result:
+            deduplicated_result.append((
+                installer_key,
+                list(OrderedDict.fromkeys(install_keys))
+            ))
+        return deduplicated_result
 
     def __get_ordered_uninstalled(self, key):
         uninstalled = []


### PR DESCRIPTION
Duplicates in resolved dependencies are uncommon, but one such case is [`ffmpeg`](https://github.com/ros/rosdistro/blob/cfe61316fcb3af6a4790c1b96edb8f1912a70e9e/rosdep/base.yaml#L1006) and [`libswscale-dev`](https://github.com/ros/rosdistro/blob/cfe61316fcb3af6a4790c1b96edb8f1912a70e9e/rosdep/base.yaml#L5350), where both depend on the `libswscale-dev` apt package. Trying to install them simultaneously fails with

```
ERROR: the following rosdeps failed to install
  apt: Failed to detect successful installation of [libswscale-dev]
  apt: Failed to detect successful installation of [libswscale-dev]
```

This appears to be caused by [`debian._read_apt_cache_showpkg()`](https://github.com/ros-infrastructure/rosdep/blob/b6ad1896e89feff9c5328b7baa708187d790d1e1/src/rosdep2/platforms/debian.py#L156-L221) assuming a roughly one-to-one correspondence between the `packages` input list and the output lines from `apt-cache showpkg`. Due to the latter ignoring any duplicates, the resulting list of dependencies to be installed gets corrupted and some of them will fail to be installed.

As a fix, this PR removes any duplicates in the list of resolved dependencies (without affecting the order). 