### PR TITLE
Support --sources-cache-dir option for the update command.

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -653,7 +653,7 @@ def command_update(options):
     try:
         if not options.quiet:
             print('reading in sources list data from %s' % (sources_list_dir))
-        sources_cache_dir = get_sources_cache_dir()
+        sources_cache_dir = options.sources_cache_dir if options.sources_cache_dir else get_sources_cache_dir()
         try:
             if os.geteuid() == 0:
                 print("Warning: running 'rosdep update' as root is not recommended.", file=sys.stderr)
@@ -661,7 +661,8 @@ def command_update(options):
         except AttributeError:
             # nothing we wanna do under Windows
             pass
-        update_sources_list(success_handler=update_success_handler,
+        update_sources_list(sources_cache_dir=sources_cache_dir,
+                            success_handler=update_success_handler,
                             error_handler=update_error_handler,
                             skip_eol_distros=not options.include_eol_distros,
                             ros_distro=options.ros_distro,


### PR DESCRIPTION
Currently, the sources cache location cannot be configured when calling `rosdep update` from command line. This could be helpful e.g. on the buildfarm or in CI scripts - it would then be possible to completely isolate the build from the host environment and filesystem - `ROSDEP_SOURCE_PATH` would define the sources list path for both `init` and `update` commands, and `--sources-cache-dir` would then specify the cache path for `update`.

The `install` verb already respects the `--sources-cache-dir` option, so it would be possible to call the `install` command against the custom cache location created by the `update` command.

I haven't figured out a way to write a test for the changes, as there is no existing test for the `update` verb. But I hope the changes are simple enough to go through without tests. Locally, I tested the `update` verb both with and without the argument and it behaves as expected.