### PR TITLE
Handle pip package versions like pip does [rev2]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ elif 'SKIP_PYTHON_SCRIPTS' in os.environ:
     kwargs['name'] += '_modules'
     kwargs['entry_points'] = {}
 else:
-    kwargs['install_requires'] += ['catkin_pkg >= 0.4.0', 'rospkg >= 1.4.0', 'rosdistro >= 0.7.5']
+    kwargs['install_requires'] += ['catkin_pkg >= 0.4.0', 'rospkg >= 1.4.0', 'rosdistro >= 0.7.5', 'packaging']
 
 setup(**kwargs)

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -108,7 +108,7 @@ def pip_detect(pkgs, exec_fn=None):
     if exec_fn is None:
         exec_fn = read_stdout
         fallback_to_pip_show = True
-    pkg_list = exec_fn(pip_cmd + ['freeze']).split('\n')
+    pkg_list = exec_fn(pip_cmd + ['list', '--format', 'freeze']).split('\n')
     pkg_list = [p for p in pkg_list if len(p) > 0]
 
     ret_list = []

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -102,6 +102,10 @@ def pip_detect(pkgs, exec_fn=None):
 
     for pkg in pkg_list:
         pkg_row = pkg.split('==')
+        
+        # Account for some unusual instances of === instead of ==
+        pkg_row[1] = pkg_row[1].strip('=')
+
         version_list.append((pkg_row[0], Version(pkg_row[1])))
 
     for pkg in pkgs:

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -17,8 +17,8 @@ X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [rosdep_modules]
-Depends: ca-certificates, python-rospkg-modules (>= 1.4.0), python-yaml, python-catkin-pkg-modules (>= 0.4.0), python-rosdistro-modules (>= 0.7.5), python-setuptools, sudo
-Depends3: ca-certificates, python3-rospkg-modules (>= 1.4.0), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), python3-setuptools, sudo
+Depends: ca-certificates, python-rospkg-modules (>= 1.4.0), python-yaml, python-catkin-pkg-modules (>= 0.4.0), python-rosdistro-modules (>= 0.7.5), python-setuptools, python-packaging, sudo
+Depends3: ca-certificates, python3-rospkg-modules (>= 1.4.0), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), python3-setuptools, python3-packaging, sudo
 Conflicts: python-rosdep (<< 0.18.0), python-rosdep2
 Conflicts3: python3-rosdep (<< 0.18.0), python3-rosdep2
 Replaces: python-rosdep (<< 0.18.0)

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -62,6 +62,21 @@ def test_pip_detect():
     val = pip_detect(['paramiko', 'fakito', 'pycrypto'], exec_fn=m)
     assert val == ['paramiko', 'pycrypto'], val
 
+    val = pip_detect(['paramiko', 'Brlapi==0.5.4', 'pycrypto'], exec_fn=m)
+    assert val == ['paramiko', 'Brlapi', 'pycrypto'], val
+
+    val = pip_detect(['paramiko', 'Brlapi==0.5.5', 'pycrypto'], exec_fn=m)
+    assert val == ['paramiko', 'pycrypto'], val
+
+    val = pip_detect(['Brlapi>0.5.*'], exec_fn=m)
+    assert val == ['Brlapi'], val
+
+    val = pip_detect(['Brlapi>0.5.*,<0.6'], exec_fn=m)
+    assert val == ['Brlapi'], val
+
+    val = pip_detect(['Brlapi>0.5.*,<0.5.4'], exec_fn=m)
+    assert val == [], val
+
 
 def test_PipInstaller_get_depends():
     # make sure PipInstaller supports depends

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -65,13 +65,13 @@ def test_pip_detect():
     val = pip_detect(['paramiko', 'Brlapi==0.5.5', 'pycrypto'], exec_fn=m)
     assert val == ['paramiko', 'pycrypto'], val
 
-    val = pip_detect(['Brlapi>0.5.*'], exec_fn=m)
+    val = pip_detect(['Brlapi>0.5'], exec_fn=m)
     assert val == ['Brlapi'], val
 
-    val = pip_detect(['Brlapi>0.5.*,<0.6'], exec_fn=m)
+    val = pip_detect(['Brlapi>0.5,<0.6'], exec_fn=m)
     assert val == ['Brlapi'], val
 
-    val = pip_detect(['Brlapi>0.5.*,<0.5.4'], exec_fn=m)
+    val = pip_detect(['Brlapi>0.5,<0.5.4'], exec_fn=m)
     assert val == [], val
 
 


### PR DESCRIPTION
Continuation of #901.

This would come handy e.g. with package m2r added in https://github.com/ros/rosdistro/pull/35827 , where the newest released version on pip is python3-only, but it is also offered on python2 pip on bionic.