### PR TITLE
Require flake8 < 6 for linting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ kwargs = {
     'install_requires': ['PyYAML >= 3.1', 'setuptools'],
     'extras_require': {
         'test': [
-            'flake8',
+            'flake8 < 6',
             'flake8-comprehensions',
             "mock; python_version < '3.3'",
             'pytest',


### PR DESCRIPTION
It seems that flake8 6 is ignoring the style guide in test_flake8.py under certain conditions, namely on macOS.

Fixes #912 