### PR TITLE
Optionally supress ``sudo rosdep update`` warning with flag

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -378,6 +378,9 @@ def _rosdep_main(args):
                       default=[], action='append',
                       help='Dependency types to install, can be given multiple times. '
                            'Choose from {}. Default: all except doc.'.format(VALID_DEPENDENCY_TYPES))
+    parser.add_option('--supress-warning-sudo', dest='supress_warning_sudo', default=False,
+                      action='store_true', help='Suppress warning about sudo usage. '
+                      'This is useful if you are using rosdep in a docker container.')
 
     options, args = parser.parse_args(args)
     if options.print_version or options.print_all_versions:
@@ -655,7 +658,7 @@ def command_update(options):
             print('reading in sources list data from %s' % (sources_list_dir))
         sources_cache_dir = get_sources_cache_dir()
         try:
-            if os.geteuid() == 0:
+            if os.geteuid() == 0 and not options.supress_warning_sudo:
                 print("Warning: running 'rosdep update' as root is not recommended.", file=sys.stderr)
                 print("  You should run 'sudo rosdep fix-permissions' and invoke 'rosdep update' again without sudo.", file=sys.stderr)
         except AttributeError:


### PR DESCRIPTION
This adds a flag to simply supress the warning if a user wants to.
It seems better than telling everyone to ignore the warning if using docker (which is often root).

Resolves: #473