### PR TITLE
Update rosdep help and logging for ROS 2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist
 src/rosdep.egg-info
 nose*
 _build
+install
+log

--- a/src/rosdep2/catkin_packages.py
+++ b/src/rosdep2/catkin_packages.py
@@ -25,12 +25,12 @@ def find_catkin_packages_in(path, verbose=False):
     if not os.path.exists(path):
         raise OSError("given path '{0}' does not exist".format(path))
     if verbose:
-        print("Looking for packages in '{0}'... ".format(path),
-              end='', file=sys.stderr)
+        print("Looking for catkin packages in '{0}'... ".format(path),
+              end='')
     path = os.path.abspath(path)
     if path in _catkin_packages_cache:
         if verbose:
-            print('found in cache.', file=sys.stderr)
+            print('found in cache.')
         return _catkin_packages_cache[path]
     packages = find_packages(path)
     if type(packages) == dict and packages != {}:
@@ -43,7 +43,7 @@ def find_catkin_packages_in(path, verbose=False):
         return package_names
     else:
         if verbose:
-            print('failed to find packages.', file=sys.stderr)
+            print('failed to find packages.')
         return []
 
 

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -404,6 +404,8 @@ class RosdepLookup(object):
         for resource_name in resources:
             try:
                 rosdep_keys = self.get_rosdeps(resource_name, implicit=implicit)
+                # Make key list unique
+                rosdep_keys = list(set(rosdep_keys))
                 if self.verbose:
                     print('resolve_all: resource [%s] requires rosdep keys [%s]' % (resource_name, ', '.join(rosdep_keys)), file=sys.stderr)
                 rosdep_keys = prune_catkin_packages(rosdep_keys, self.verbose)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -89,11 +89,21 @@ _usage = """usage: rosdep [options] <command> <args>
 
 Commands:
 
+rosdep check <folders>... --from-paths
+  ROS 1 or 2 usage. Check for unmet dependencies of the catkin packages
+  located in the given <folders>.
+
 rosdep check <stacks-and-packages>...
-  check if the dependencies of package(s) have been met.
+  ROS 1 usage. Check if the dependencies of package(s) have been met.
+  Searches workspace for manifest.xml and stack.xml files.
+
+rosdep install <folders>... --from-paths
+  ROS 1 or 2 usage. Download and install the unmet dependencies of the catkin
+  packages located in the given <folders>.
 
 rosdep install <stacks-and-packages>...
-  download and install the dependencies of a given package or packages.
+  ROS 1 usage. Download and install the dependencies of a given package 
+  or packages.
 
 rosdep db
   generate the dependency database and print it to the console.
@@ -101,8 +111,12 @@ rosdep db
 rosdep init
   initialize rosdep sources in /etc/ros/rosdep.  May require sudo.
 
+rosdep keys <folders>... --from-paths
+  ROS 1 or 2 usage. List the dependencies of the catkin packages located in 
+  the given <folders>.
+
 rosdep keys <stacks-and-packages>...
-  list the rosdep keys that the packages depend on.
+  ROS 1 usage. List the rosdep keys that the packages depend on.
 
 rosdep resolve <rosdeps>
   resolve <rosdeps> to system dependencies
@@ -330,10 +344,10 @@ def _rosdep_main(args):
     parser.add_option('--ignore-packages-from-source', '--ignore-src', '-i',
                       dest='ignore_src', default=False, action='store_true',
                       help="Affects the 'check', 'install', and 'keys' verbs. "
-                           'If specified then rosdep will ignore keys that '
-                           'are found to be catkin or ament packages anywhere in the '
-                           'ROS_PACKAGE_PATH, AMENT_PREFIX_PATH or in any of the directories '
-                           'given by the --from-paths option.')
+                           'Causes rosdep to fulfill dependencies not only via installed '
+                           'packages (as normal), but also via the workspace packages '
+                           '(i.e., the catkin and ament packages located in the '
+                           'ROS_PACKAGE_PATH or AMENT_PREFIX_PATH or --from-paths folders).')
     parser.add_option('--skip-keys',
                       dest='skip_keys', action='append', default=[],
                       help="Affects the 'check' and 'install' verbs. The "
@@ -514,7 +528,7 @@ def _package_args_handler(command, parser, options, args):
     # Handle the --ignore-src option
     if command in ['install', 'check', 'keys'] and options.ignore_src:
         if options.verbose:
-            print('Searching ROS_PACKAGE_PATH for '
+            print('--ignore-src: Searching ROS_PACKAGE_PATH for '
                   'sources: ' + str(os.environ['ROS_PACKAGE_PATH'].split(os.pathsep)))
         ws_pkgs = get_workspace_packages()
         for path in os.environ['ROS_PACKAGE_PATH'].split(os.pathsep):
@@ -530,10 +544,13 @@ def _package_args_handler(command, parser, options, args):
         if AMENT_PREFIX_PATH_ENV_VAR in os.environ:
             if options.verbose:
                 print(
-                    'Searching ' + AMENT_PREFIX_PATH_ENV_VAR + ' for '
+                    '--ignore-src: Searching ' + AMENT_PREFIX_PATH_ENV_VAR + ' for '
                     'sources: ' + str(os.environ[AMENT_PREFIX_PATH_ENV_VAR].split(':')))
             ws_pkgs = get_workspace_packages()
             pkgs = get_packages_with_prefixes().keys()
+            if options.verbose:
+                for package in pkgs:
+                    print('    {0}'.format(package))
             ws_pkgs.extend(pkgs)
             # Make packages list unique
             ws_pkgs = list(set(ws_pkgs))


### PR DESCRIPTION
[Problem]
- Git staging is cluttered with build files in install/ and log/.
- Argument <stacks-and-packages> (which relies on stack.xml and manifest.xml) does not make sense for ROS 2.
- Help text for --ignore-src is unclear whether it ignores the input pkgs or the dependency pkgs or both.
- The --verbose output does not show all the packages that rosdep thinks are installed (or available in the workspace).
- The --verbose output prints some lines out of order.
- The --verbose output prints dupes of keys, e.g., "resolve_all: rsource [pkg3] requires rosdep keys [pkg1 pkg1 pkg1]", followed by 3 identical lines describing the action.

[Solution]
- Modified .gitignore. Verified that the repo does not currently have any files in install/ or log/.
- Modified command usage. Split the check, install, and key commands into variants "ROS 1 or 2" and "ROS 1".
- Modified help text for --ignore-src. Added "--ignore-src:" marker to verbose log lines.
- Added verbose logging for --ignore-src that displays the packages that rosdep finds at AMENT_PREFIX_PATH_ENV_VAR. (The first part of --ignore-src, where it finds ROS_PACKAGE_PATH packages, already has verbose logging via find_catkin_packages_in().)
- Updated verbose logging in find_catkin_packages_in() so that it is on stdout and, therefore, prints in order with the other stdout lines.
- Updated resolve_all() to make the list of rosdep_keys unique.

[Test]
- Manual, local test on jammy-amd64.