### PR TITLE
Does not check python packages installed via GitHub url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ kwargs = {
     # same version as in:
     # - src/rosdep2/__init__.py
     # - stdeb.cfg
-    'version': '0.22.2',
+    'version': '0.22.3',
     'packages': ['rosdep2', 'rosdep2.ament_packages', 'rosdep2.platforms'],
     'package_dir': {'': 'src'},
     'install_requires': ['PyYAML >= 3.1', 'setuptools'],

--- a/src/rosdep2/_version.py
+++ b/src/rosdep2/_version.py
@@ -1,4 +1,4 @@
 # same version as in:
 # - setup.py
 # - stdeb.cfg
-__version__ = '0.22.2'
+__version__ = '0.22.3'

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,11 +2,11 @@
 ; rosdep-modules same version as in:
 ; - setup.py
 ; - src/rosdep2/_version.py
-Depends: python-rosdep-modules (>= 0.22.2)
+Depends: python-rosdep-modules (>= 0.22.3)
 ; rosdep-modules same version as in:
 ; - setup.py
 ; - src/rosdep2/_version.py
-Depends3: python3-rosdep-modules (>= 0.22.2)
+Depends3: python3-rosdep-modules (>= 0.22.3)
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE


### PR DESCRIPTION
Does not check if the installation was successful when the python package was provided via URL, for example 
```
pip install <GITHUB_URL>
```
The URL does not contain the package name it is just a path to the setup.py.