### PR TITLE
fix: pkg_resources deprecated warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ kwargs = {
     'version': '0.22.2',
     'packages': ['rosdep2', 'rosdep2.ament_packages', 'rosdep2.platforms'],
     'package_dir': {'': 'src'},
-    'install_requires': ['PyYAML >= 3.1', 'setuptools'],
+    'install_requires': [
+        'PyYAML >= 3.1',
+        'setuptools',
+        'importlib_metadata; python_version<"3.8"'
+    ],
     'extras_require': {
         'test': [
             'flake8 < 6',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ kwargs = {
     'package_dir': {'': 'src'},
     'install_requires': [
         'PyYAML >= 3.1',
-        'setuptools',
         'importlib_metadata; python_version<"3.8"'
     ],
     'extras_require': {

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -29,10 +29,14 @@
 
 from __future__ import print_function
 
-import importlib.metadata
 import os
 import subprocess
 import sys
+
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 from ..core import InstallFailed
 from ..installers import PackageManagerInstaller
@@ -130,8 +134,8 @@ class PipInstaller(PackageManagerInstaller):
         super(PipInstaller, self).__init__(pip_detect, supports_depends=True)
 
     def get_version_strings(self):
-        pip_version = importlib.metadata.version('pip')
-        setuptools_version = importlib.metadata.version('setuptools')
+        pip_version = importlib_metadata.version('pip')
+        setuptools_version = importlib_metadata.version('setuptools')
         version_strings = [
             'pip {}'.format(pip_version),
             'setuptools {}'.format(setuptools_version),

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -135,6 +135,7 @@ class PipInstaller(PackageManagerInstaller):
 
     def get_version_strings(self):
         pip_version = importlib_metadata.version('pip')
+        # keeping the name "setuptools" for backward compatibility
         setuptools_version = importlib_metadata.version('setuptools')
         version_strings = [
             'pip {}'.format(pip_version),

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -29,8 +29,8 @@
 
 from __future__ import print_function
 
+import importlib.metadata
 import os
-import pkg_resources
 import subprocess
 import sys
 
@@ -130,8 +130,8 @@ class PipInstaller(PackageManagerInstaller):
         super(PipInstaller, self).__init__(pip_detect, supports_depends=True)
 
     def get_version_strings(self):
-        pip_version = pkg_resources.get_distribution('pip').version
-        setuptools_version = pkg_resources.get_distribution('setuptools').version
+        pip_version = importlib.metadata.version('pip')
+        setuptools_version = importlib.metadata.version('setuptools')
         version_strings = [
             'pip {}'.format(pip_version),
             'setuptools {}'.format(setuptools_version),

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -18,7 +18,7 @@ Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [rosdep_modules]
 Depends: ca-certificates, python-rospkg-modules (>= 1.4.0), python-yaml, python-catkin-pkg-modules (>= 0.4.0), python-rosdistro-modules (>= 0.7.5), python-setuptools, sudo
-Depends3: ca-certificates, python3-rospkg-modules (>= 1.4.0), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), python3-setuptools, sudo
+Depends3: ca-certificates, python3-rospkg-modules (>= 1.4.0), python3-yaml, python3-catkin-pkg-modules (>= 0.4.0), python3-rosdistro-modules (>= 0.7.5), python3 (>= 3.8) | python3-importlib-metadata, sudo
 Conflicts: python-rosdep (<< 0.18.0), python-rosdep2
 Conflicts3: python3-rosdep (<< 0.18.0), python3-rosdep2
 Replaces: python-rosdep (<< 0.18.0)

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -114,6 +114,13 @@ def test_PipInstaller():
         raise
 
 
+def test_PipInstaller_get_version_strings():
+    from rosdep2.platforms.pip import PipInstaller
+
+    installer = PipInstaller()
+    assert installer.get_version_strings()
+
+
 def test_get_pip_command():
     from rosdep2.platforms.pip import get_pip_command
 


### PR DESCRIPTION
This pr fixes a warning caused by `pkg_resources`, by using `importlib.metadata` instead.

`Importlib.metadata` is supported since py3.8, which is shipped with the oldest supported ROS1/2 distro (noetic, Ubuntu 20.04)

[Same warning in colcon](https://github.com/colcon/colcon-core/issues/552) (maybe resolved)