### PR TITLE
Use setup.cfg to configure flake8, instead of in the ci code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,16 +12,26 @@ exclude =
   conf.py,
   .venv,
 ignore =
-  C402,  # ignore presence of unnecessary generators
-  C405,  # ignore presence of unnecessary literals
-  C407,  # ignore presence of unnecessary comprehensions
-  C408,  # ignore presence of unnecessary tuple/list/dict
-  D,  # ignore documentation related warnings
-  F401,  # ignore presence of unused imports
-  F841,  # ignore presence of unused variables
-  I,  # ignore import order related warnings
-  N802,  # ignore presence of upper case in function names
-  W504,  # ignore line breaks after binary operator (new rule added in 2018)
+  # ignore presence of unnecessary generators
+  C402,
+  # ignore presence of unnecessary literals
+  C405,
+  # ignore presence of unnecessary comprehensions
+  C407,
+  # ignore presence of unnecessary tuple/list/dict
+  C408,
+  # ignore documentation related warnings
+  D,
+  # ignore presence of unused imports
+  F401,
+  # ignore presence of unused variables
+  F841,
+  # ignore import order related warnings
+  I,
+  # ignore presence of upper case in function names
+  N802,
+  # ignore line breaks after binary operator (new rule added in 2018)
+  W504,
 max-line-length = 200
 max-complexity = 10
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ ignore =
   # ignore line breaks after binary operator (new rule added in 2018)
   W504,
 max-line-length = 200
-max-complexity = 10
+max-complexity = 26
 
 [coverage:run]
 source = rosdep2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,23 @@ markers =
   linter
   online
 
+[flake8]
+exclude =
+  conf.py,
+  .venv,
+ignore =
+  C402,  # ignore presence of unnecessary generators
+  C405,  # ignore presence of unnecessary literals
+  C407,  # ignore presence of unnecessary comprehensions
+  C408,  # ignore presence of unnecessary tuple/list/dict
+  D,  # ignore documentation related warnings
+  F401,  # ignore presence of unused imports
+  F841,  # ignore presence of unused variables
+  I,  # ignore import order related warnings
+  N802,  # ignore presence of upper case in function names
+  W504,  # ignore line breaks after binary operator (new rule added in 2018)
+max-line-length = 200
+max-complexity = 10
+
 [coverage:run]
 source = rosdep2

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ ignore =
   # ignore line breaks after binary operator (new rule added in 2018)
   W504,
 max-line-length = 200
+# due to complexity not being enforced before, 26 is the minimum for not
+# throwing errors.
 max-complexity = 26
 
 [coverage:run]

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-import pathlib
+import os
 import subprocess
 import sys
 
@@ -27,14 +27,10 @@ def test_flake8():
     # flake8 doesn't have a stable public API as of ver 6.1.0.
     # See: https://flake8.pycqa.org/en/latest/user/python-api.html
     # Calling through subprocess is the most stable way to run it.
-    result = subprocess.run(
-        [sys.executable, '-m', 'flake8'],
-        stdout=subprocess.PIPE,  # capture_output doesn't work on py3.6
-        stderr=subprocess.PIPE,
+
+    # We still need to support Python 2.7, so we can't use run()
+    ret_code = subprocess.call(
+        [sys.executable, "-m", "flake8"],
         cwd=os.path.dirname(os.path.dirname(__file__)),
-        check=False,
     )
-    # pipe stdout to stdout, stderr to stderr
-    print(result.stdout.decode('utf-8'), end='')
-    print(result.stderr.decode('utf-8'), end='', file=sys.stderr)
-    assert 0 == result.returncode, "flake8 found violations"
+    assert 0 == ret_code, "flake8 found violations"

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -28,10 +28,10 @@ def test_flake8():
     # See: https://flake8.pycqa.org/en/latest/user/python-api.html
     # Calling through subprocess is the most stable way to run it.
     result = subprocess.run(
-        ['flake8'],
+        [sys.executable, '-m', 'flake8'],
         stdout=subprocess.PIPE,  # capture_output doesn't work on py3.6
         stderr=subprocess.PIPE,
-        cwd=pathlib.Path(__file__).parent.parent,
+        cwd=os.path.dirname(os.path.dirname(__file__)),
         check=False,
     )
     # pipe stdout to stdout, stderr to stderr

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -29,8 +29,9 @@ def test_flake8():
     # Calling through subprocess is the most stable way to run it.
     result = subprocess.run(
         ['flake8'],
+        stdout=subprocess.PIPE,  # capture_output doesn't work on py3.6
+        stderr=subprocess.PIPE,
         cwd=pathlib.Path(__file__).parent.parent,
-        capture_output=True,
         check=False,
     )
     # pipe stdout to stdout, stderr to stderr

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -24,6 +24,9 @@ import pytest
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
+    # flake8 doesn't have a stable public API as of ver 6.1.0.
+    # See: https://flake8.pycqa.org/en/latest/user/python-api.html
+    # Calling through subprocess is the most stable way to run it.
     result = subprocess.run(
         ['flake8'],
         cwd=pathlib.Path(__file__).parent.parent,

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -14,50 +14,23 @@
 
 from __future__ import print_function
 
-import os
+import pathlib
+import subprocess
 import sys
 
-from flake8.api.legacy import get_style_guide
 import pytest
 
 
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
-    style_guide = get_style_guide(
-        exclude=['conf.py'],
-        ignore=[
-            'C402',  # ignore presence of unnecessary generators
-            'C405',  # ignore presence of unnecessary literals
-            'C407',  # ignore presence of unnecessary comprehensions
-            'C408',  # ignore presence of unnecessary tuple/list/dict
-            'D',  # ignore documentation related warnings
-            'F401',  # ignore presence of unused imports
-            'F841',  # ignore presence of unused variables
-            'I',  # ignore import order related warnings
-            'N802',  # ignore presence of upper case in function names
-            'W504',  # ignore line breaks after binary operator (new rule added in 2018)
-        ],
-        max_line_length=200,
-        max_complexity=10,
-        show_source=True,
+    result = subprocess.run(
+        ['flake8'],
+        cwd=pathlib.Path(__file__).parent.parent,
+        capture_output=True,
+        check=False,
     )
-
-    stdout = sys.stdout
-    sys.stdout = sys.stderr
-    # implicitly calls report_errors()
-    report = style_guide.check_files([
-        os.path.dirname(os.path.dirname(__file__)),
-    ])
-    sys.stdout = stdout
-
-    if report.total_errors:
-        # output summary with per-category counts
-        print()
-        report._application.formatter.show_statistics(report._stats)
-        print(
-            'flake8 reported {report.total_errors} errors'
-            .format(**locals()), file=sys.stderr)
-
-    assert not report.total_errors, \
-        'flake8 reported {report.total_errors} errors'.format(**locals())
+    # pipe stdout to stdout, stderr to stderr
+    print(result.stdout.decode('utf-8'), end='')
+    print(result.stderr.decode('utf-8'), end='', file=sys.stderr)
+    assert 0 == result.returncode, "flake8 found violations"


### PR DESCRIPTION
This makes flake8's configuration more discoverable and easier to use with other tools (IDE, etc.).

~~Regression: it seems that "max-complexity" wasn't properly enforced, now a lot of code is detected as too complex. (warn if > 10, max is 25)
We may need to adjust the value.~~
Complexity adjusted to 26 to satisfy the current code's needs.