### PR TITLE
Fix ci: ubuntu 18 and python 2.7 are deprecated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,7 @@ jobs:
           os: [ubuntu-latest, macos-latest]
           python: ['3.7', '3.8', '3.9', '3.10']
           include:
-          - os: ubuntu-18.04
-            python: '2.7'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python: '3.6'
       name: rosdep tests
       runs-on: ${{matrix.os}}


### PR DESCRIPTION
Currently, Ubuntu 18 is letting the ci not finishing. [example](https://github.com/ros-infrastructure/rosdep/actions/runs/5886184447/job/15964654004)
This is due to ubuntu 18 being deprecated in GHA. https://github.com/actions/runner-images/issues/6002

This PR does the following changes:

- Change ubuntu 18 -> 20
- Remove python 2.7

Python 3.6 is kept for compatibility with RH8 and derivatives.