### PR TITLE
Update deb platforms for release

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE
 Suite: bionic buster
-Suite3: bionic focal jammy buster bullseye
+Suite3: focal jammy noble bookworm trixie
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
@@ -25,7 +25,7 @@ Replaces: python-rosdep (<< 0.18.0)
 Replaces3: python3-rosdep (<< 0.18.0)
 Copyright-File: LICENSE
 Suite: bionic buster
-Suite3: bionic focal jammy buster bullseye
+Suite3: focal jammy noble bookworm trixie
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Bookworm (stable)
* Debian Trixie (testing)

Dropped:
* Debian Buster (oldoldstable)
* Debian Bullseye (oldstable)
* Ubuntu Bionic (18.04 LTS)

Retained:
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)