### PR TITLE
Teach rosdep to use ROS_VERSION when resolving conditionals

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -286,6 +286,12 @@ def setup_environment_variables(ros_distro):
                 del os.environ['ROS_PYTHON_VERSION']
         os.environ['ROS_DISTRO'] = ros_distro
 
+    if 'ROS_VERSION' not in os.environ and 'ROS_DISTRO' in os.environ:
+        # Set ROS version to version used by ROS distro
+        ros_versions = MetaDatabase().get('ROS_VERSION', default=[])
+        if os.environ['ROS_DISTRO'] in ros_versions:
+            os.environ['ROS_VERSION'] = str(ros_versions[os.environ['ROS_DISTRO']])
+
     if 'ROS_PYTHON_VERSION' not in os.environ and 'ROS_DISTRO' in os.environ:
         # Set python version to version used by ROS distro
         python_versions = MetaDatabase().get('ROS_PYTHON_VERSION', default=[])

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -484,6 +484,12 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
     # Additional sources for ros distros
     # In compliance with REP137 and REP143
     python_versions = {}
+    ros_versions = {}
+
+    ros_version_map = {
+        'ros1': '1',
+        'ros2': '2',
+    }
 
     if not quiet:
         print('Query rosdistro index %s' % get_index_url())
@@ -508,9 +514,13 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
             print('Add distro "%s"' % dist_name)
         rds = RosDistroSource(dist_name)
         rosdep_data = get_gbprepo_as_rosdep_data(dist_name)
-        # Store Python version from REP153
+        # Store metadata from REP153
         if distribution.get('python_version'):
             python_versions[dist_name] = distribution.get('python_version')
+        if distribution.get('distribution_type'):
+            distribution_type = distribution.get('distribution_type')
+            if distribution_type in ros_version_map:
+                ros_versions[dist_name] = ros_version_map[distribution_type]
         # dist_files can either be a string (single filename) or a list (list of filenames)
         dist_files = distribution['distribution']
         key = _generate_key_from_urls(dist_files)
@@ -518,7 +528,9 @@ def update_sources_list(sources_list_dir=None, sources_cache_dir=None,
         sources.append(rds)
 
     # cache metadata that isn't a source list
-    MetaDatabase().set('ROS_PYTHON_VERSION', python_versions)
+    meta_db = MetaDatabase()
+    meta_db.set('ROS_PYTHON_VERSION', python_versions)
+    meta_db.set('ROS_VERSION', ros_versions)
 
     # Create a combined index of *all* the sources.  We do all the
     # sources regardless of failures because a cache from a previous


### PR DESCRIPTION
The metadata from REP153 includes the `ROS_PYTHON_VERSION`, which is currently cached during a call to `rosdep update` so that it is available to package manifest conditionals during rosdep operations in an environment where `ROS_PYTHON_VERSION` is not already set.

This change extends that metadata caching to include the `ROS_VERSION` variable as well. These two values combined with `ROS_DISTRO`, are the three variables [supplied by Bloom](https://github.com/ros-infrastructure/bloom/blob/d3d21ae9e816500154798d254422ac30e6bbee0f/bloom/generators/common.py#L157-L161) during manifest conditional evaluation. It makes sense to treat them the same way here.

Reproduction:
1. Start with a clean environment with no workspaces sourced
2. `$ git clone https://github.com/autowarefoundation/tvm_vendor.git` (or any package which uses `ROS_VERSION`)
3. `$ rosdep keys --rosdistro humble --from-path tvm_vendor`

Expected results:
```
ocl-icd-opencl-dev
spirv-headers
libopenblas-dev
git
libxml2
opencl-headers
ament_cmake
spirv-tools
ros_environment
libvulkan-dev
```

Actual results:
```
libopenblas-dev
libxml2
ros_environment
git
```