### PR TITLE
Print exception if it's of type URLError

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -603,6 +603,7 @@ def command_init(options):
         data = download_default_sources_list()
     except URLError as e:
         print('ERROR: cannot download default sources list from:\n%s\nWebsite may be down.' % (DEFAULT_SOURCES_LIST_URL), file=sys.stderr)
+        print(e, file=sys.stderr)
         return 4
     except DownloadFailure as e:
         print('ERROR: cannot download default sources list from:\n%s\nWebsite may be down.' % (DEFAULT_SOURCES_LIST_URL), file=sys.stderr)


### PR DESCRIPTION
This prints the exception out if it's of type `URLError` when trying to retrieve the default rosdep source list. This is intended to help others debug ros-infrastructure/rosdep#934 should they run into it.