### PR TITLE
Return non-zero if `rosdep check` cannot locate dependent

### DIFF
--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -734,8 +734,10 @@ def command_check(lookup, packages, options):
                 print('ERROR[%s]: resource not found [%s]' % (package_name, ex.args[0]), file=sys.stderr)
             else:
                 print('ERROR[%s]: %s' % (package_name, ex), file=sys.stderr)
-    if uninstalled or errors:
+    if uninstalled:
         return 1
+    elif errors:
+        return 2
     else:
         return 0
 

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -734,7 +734,7 @@ def command_check(lookup, packages, options):
                 print('ERROR[%s]: resource not found [%s]' % (package_name, ex.args[0]), file=sys.stderr)
             else:
                 print('ERROR[%s]: %s' % (package_name, ex), file=sys.stderr)
-    if uninstalled:
+    if uninstalled or errors:
         return 1
     else:
         return 0


### PR DESCRIPTION
This fixes #937.

As for the tests, I concluded it'll be quite difficult to implement with the current architecture.
The reason being the data in `./test/tree` is expected to succeed, see [here](https://github.com/ros-infrastructure/rosdep/blob/e48589c676e45f7ef90599edd86b742de3a9c9ef/test/test_rosdep_main.py#L195).

Please tell me if there's a good way to inject a non-functioning package, I'll add a test.