### PR TITLE
Implement test fixture for faking the rosdistro repo

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,93 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import os
+
+try:
+    from urllib.parse import urljoin
+    from urllib.request import pathname2url
+except ImportError:
+    from urlparse import urljoin
+    from urllib import pathname2url
+
+import pytest
+
+
+def path_to_url(path):
+    return urljoin('file:', pathname2url(path))
+
+
+def _restore_env_vars(old_vars):
+    for k, v in old_vars.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+@pytest.fixture
+def fake_sources_list_d(tmpdir):
+    sources_list_d = str(tmpdir)
+
+    fake_rosdep_dir = os.path.join(os.path.dirname(__file__), 'fake_rosdistro', 'rosdep')
+    default_sources_list = os.path.join(sources_list_d, '20-default.list')
+    f = open(default_sources_list, 'w')
+    f.write('\n'.join([
+        'yaml ' + path_to_url(os.path.join(fake_rosdep_dir, 'base.yaml')),
+        'yaml ' + path_to_url(os.path.join(fake_rosdep_dir, 'python.yaml')),
+    ]))
+    f.close()
+
+    return sources_list_d
+
+
+@pytest.fixture
+def fake_rosdep_source(fake_sources_list_d, request):
+    restore_env_vars = {
+        'ROSDEP_SOURCE_PATH': os.environ.get('ROSDEP_SOURCE_PATH'),
+    }
+    request.addfinalizer(functools.partial(_restore_env_vars, restore_env_vars))
+    rosdep_source = path_to_url(fake_sources_list_d)
+    os.environ['ROSDEP_SOURCE_PATH'] = rosdep_source
+    return rosdep_source
+
+
+@pytest.fixture
+def fake_ros_home(tmpdir, request):
+    ros_home = str(tmpdir)
+    restore_env_vars = {
+        'ROS_HOME': os.environ.get('ROS_HOME'),
+    }
+    request.addfinalizer(functools.partial(_restore_env_vars, restore_env_vars))
+    os.environ['ROS_HOME'] = ros_home
+    return ros_home
+
+
+@pytest.fixture
+def fake_rosdistro_index(request):
+    restore_env_vars = {
+        'ROSDISTRO_INDEX_URL': os.environ.get('ROSDISTRO_INDEX_URL'),
+    }
+    request.addfinalizer(functools.partial(_restore_env_vars, restore_env_vars))
+    rosdistro_index_url = path_to_url(
+        os.path.join(os.path.dirname(__file__), 'fake_rosdistro', 'index-v4.yaml'))
+    os.environ['ROSDISTRO_INDEX_URL'] = rosdistro_index_url
+    return rosdistro_index_url
+
+
+@pytest.fixture
+def fake_rosdep(fake_ros_home, fake_rosdep_source, fake_rosdistro_index):
+    from rosdep2.sources_list import update_sources_list
+    assert update_sources_list()

--- a/test/fake_rosdistro/README.md
+++ b/test/fake_rosdistro/README.md
@@ -1,0 +1,3 @@
+This content is mocking the official rosdep and rosdistro data from https://github.com/ros/rosdistro
+
+It should periodically be updated to a more recent snapshot.

--- a/test/fake_rosdistro/index-v4.yaml
+++ b/test/fake_rosdistro/index-v4.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+distributions:
+  melodic:
+    distribution: [melodic/distribution.yaml]
+    distribution_status: end-of-life
+    distribution_type: ros1
+    python_version: 2
+type: index
+version: 4

--- a/test/fake_rosdistro/melodic/distribution.yaml
+++ b/test/fake_rosdistro/melodic/distribution.yaml
@@ -1,0 +1,31 @@
+%YAML 1.1
+---
+release_platforms:
+  debian:
+    - buster
+  ubuntu:
+    - bionic
+repositories:
+  catkin:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/catkin-release.git
+      version: 0.7.29-1
+    status: maintained
+  genmsg:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/genmsg-release.git
+      version: 0.5.17-1
+    status: maintained
+  ros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ros-release.git
+      version: 1.14.9-1
+    status: maintained
+type: distribution
+version: 2

--- a/test/fake_rosdistro/rosdep/base.yaml
+++ b/test/fake_rosdistro/rosdep/base.yaml
@@ -1,0 +1,3 @@
+---
+cmake:
+  ubuntu: [cmake]

--- a/test/fake_rosdistro/rosdep/python.yaml
+++ b/test/fake_rosdistro/rosdep/python.yaml
@@ -1,0 +1,5 @@
+---
+python:
+  ubuntu: [python-dev]
+python-mock:
+  ubuntu: [python-mock]

--- a/test/test_rosdep_catkin_support.py
+++ b/test/test_rosdep_catkin_support.py
@@ -4,15 +4,11 @@ from rosdep2.platforms.debian import APT_INSTALLER
 import pytest
 
 
-@pytest.mark.online
+@pytest.mark.usefixtures('fake_rosdep')
 def test_workflow():
-    try:
-        installer = get_installer(APT_INSTALLER)
-        view = get_catkin_view('fuerte', 'ubuntu', 'lucid')
-        resolved = resolve_for_os('cmake', view, installer, 'ubuntu', 'lucid')
-        assert ['cmake'] == resolved
-        resolved = resolve_for_os('python', view, installer, 'ubuntu', 'lucid')
-        assert resolved == ['python-dev']
-    except ValidationFailed:
-        # tests fail on the server because 'rosdep init' has not been run
-        pass
+    installer = get_installer(APT_INSTALLER)
+    view = get_catkin_view('fuerte', 'ubuntu', 'lucid')
+    resolved = resolve_for_os('cmake', view, installer, 'ubuntu', 'lucid')
+    assert ['cmake'] == resolved
+    resolved = resolve_for_os('python', view, installer, 'ubuntu', 'lucid')
+    assert resolved == ['python-dev']

--- a/test/test_rosdep_gbpdistro_support.py
+++ b/test/test_rosdep_gbpdistro_support.py
@@ -52,7 +52,7 @@ def test_url_constants():
             assert False, 'URL [%s][%s] failed to download' % (url_name, url)
 
 
-@pytest.mark.online
+@pytest.mark.usefixtures('fake_rosdistro_index')
 def test_get_gbprepo_as_rosdep_data():
     from rosdep2.rosdistrohelper import get_index
     from rosdep2.gbpdistro_support import get_gbprepo_as_rosdep_data


### PR DESCRIPTION
This test was previously silently skipped when there wasn't an initialized and updated rosdep database present on the host. This change creates a 'fake' rosdep database locally and uses that to run the test. This decoupling also means that the test can run offline.