### PR TITLE
Fix makefile target test (`make test`) failing due to "cd test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ testsetup:
 	echo "running rosdep tests"
 
 test: testsetup
-	pytest
+	pytest test

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ testsetup:
 	echo "running rosdep tests"
 
 test: testsetup
-	cd test && pytest
+	pytest


### PR DESCRIPTION
Currently, `make test` fails on [test/test_rosdep_sources_list.py, line 501](https://github.com/ros-infrastructure/rosdep/blob/34815766eefe04c495b7b0a37fe93d47df9d595c/test/test_rosdep_sources_list.py#L501).
This is due to the CI system running pytest on the project root, while the makefile adds a cd to the test directory before running pytest.

This commit deletes the `cd test` from the makefile.

Related: #952