### PR TITLE
Fix potential bug in test_rosdep_sources_list.py

### DIFF
--- a/test/test_rosdep_sources_list.py
+++ b/test/test_rosdep_sources_list.py
@@ -498,8 +498,9 @@ def test_unpickle_same_results():
         import cPickle as pickle
     except ImportError:
         import pickle
-    with open(os.path.join('test', 'fixtures', 'python2cache.pickle'), 'rb') as py2_cache:
+    fixture_dir = os.path.join(os.path.dirname(__file__), 'fixtures')
+    with open(os.path.join(fixture_dir, 'python2cache.pickle'), 'rb') as py2_cache:
         py2_result = pickle.loads(py2_cache.read())
-    with open(os.path.join('test', 'fixtures', 'python3cache.pickle'), 'rb') as py3_cache:
+    with open(os.path.join(fixture_dir, 'python3cache.pickle'), 'rb') as py3_cache:
         py3_result = pickle.loads(py3_cache.read())
     assert py2_result == py3_result


### PR DESCRIPTION
When running pytest from anywhere else than the project root directory, test_rosdep_sources_list.py would fail because there were 2 hardcoded path that depended on where the test was run from.

This commit fixes this by using a relative path from the aforementioned file, which is the same logic used in other tests.

Related: #951