### PR TITLE
0.23.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,24 @@
+0.23.0 (2023-04-19)
+-------------------
+- Use setup.cfg to configure flake8, instead of in the ci code
+  - https://github.com/ros-infrastructure/rosdep/pull/930
+- Fix makefile target test (``make test``) failing due to "cd test"
+  - https://github.com/ros-infrastructure/rosdep/pull/951
+- Implement test fixture for faking the rosdistro repo
+  - https://github.com/ros-infrastructure/rosdep/pull/949
+- Return non-zero if ``rosdep check`` cannot locate dependent
+  - https://github.com/ros-infrastructure/rosdep/pull/948
+- Fix potential bug in test_rosdep_sources_list.py
+  - https://github.com/ros-infrastructure/rosdep/pull/952
+- Fix pkg_resources deprecated warning
+  - https://github.com/ros-infrastructure/rosdep/pull/926
+- Print exception if it's of type URLError
+  - https://github.com/ros-infrastructure/rosdep/pull/946
+- Teach rosdep to use ROS_VERSION when resolving conditionals
+  - https://github.com/ros-infrastructure/rosdep/pull/941
+- Resolve flake8-comprehensions violations
+  - https://github.com/ros-infrastructure/rosdep/pull/943
+
 0.22.2 (2023-03-20)
 -------------------
 - Enable rosdep init to work with non-extant ROSDEP_SOURCE_PATH

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup
 kwargs = {
     'name': 'rosdep',
     # same version as in:
-    # - src/rosdep2/__init__.py
+    # - src/rosdep2/_version.py
     # - stdeb.cfg
-    'version': '0.22.2',
+    'version': '0.23.0',
     'packages': ['rosdep2', 'rosdep2.ament_packages', 'rosdep2.platforms'],
     'package_dir': {'': 'src'},
     'install_requires': [

--- a/src/rosdep2/_version.py
+++ b/src/rosdep2/_version.py
@@ -1,4 +1,4 @@
 # same version as in:
 # - setup.py
 # - stdeb.cfg
-__version__ = '0.22.2'
+__version__ = '0.23.0'

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,11 +2,11 @@
 ; rosdep-modules same version as in:
 ; - setup.py
 ; - src/rosdep2/_version.py
-Depends: python-rosdep-modules (>= 0.22.2)
+Depends: python-rosdep-modules (>= 0.23.0)
 ; rosdep-modules same version as in:
 ; - setup.py
 ; - src/rosdep2/_version.py
-Depends3: python3-rosdep-modules (>= 0.22.2)
+Depends3: python3-rosdep-modules (>= 0.23.0)
 Conflicts: python3-rosdep, python-rosdep2, python3-rosdep2
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE


### PR DESCRIPTION
I'm not sure if we're quite ready to declare the end of Python 2 support here, but we could do that hereafter if folks are interested.

I intentionally excluded from the changelog any commits which only modified GitHub Actions behaviors. Downstream folks don't care about that.