### PR TITLE
Fix several tests which require os.geteuid

### DIFF
--- a/test/test_rosdep_alpine.py
+++ b/test/test_rosdep_alpine.py
@@ -117,9 +117,12 @@ def test_ApkInstaller():
         assert val == expected, 'Result was: %s' % val
 
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()

--- a/test/test_rosdep_arch.py
+++ b/test/test_rosdep_arch.py
@@ -58,9 +58,12 @@ def test_PacmanInstaller():
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()

--- a/test/test_rosdep_debian.py
+++ b/test/test_rosdep_debian.py
@@ -136,9 +136,12 @@ def test_AptInstaller():
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()

--- a/test/test_rosdep_freebsd.py
+++ b/test/test_rosdep_freebsd.py
@@ -72,9 +72,12 @@ def test_PkgInstaller():
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()

--- a/test/test_rosdep_gem.py
+++ b/test/test_rosdep_gem.py
@@ -106,9 +106,12 @@ def test_GemInstaller():
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()

--- a/test/test_rosdep_opensuse.py
+++ b/test/test_rosdep_opensuse.py
@@ -58,9 +58,12 @@ def test_ZypperInstaller():
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -105,9 +105,12 @@ def test_PipInstaller():
         val = installer.get_install_command(['whatever'], interactive=True)
         assert val == expected, val
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()

--- a/test/test_rosdep_redhat.py
+++ b/test/test_rosdep_redhat.py
@@ -103,9 +103,12 @@ def test_DnfInstaller():
         val = installer.get_install_command(['whatever'], interactive=True, quiet=False)
         assert val == expected, val + expected
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()
@@ -136,9 +139,12 @@ def test_YumInstaller():
         val = installer.get_install_command(['whatever'], interactive=True, quiet=False)
         assert val == expected, val + expected
     try:
-        with patch('rosdep2.installers.os.geteuid', return_value=1):
-            test(['sudo', '-H'])
-        with patch('rosdep2.installers.os.geteuid', return_value=0):
+        if hasattr(os, 'geteuid'):
+            with patch('rosdep2.installers.os.geteuid', return_value=1):
+                test(['sudo', '-H'])
+            with patch('rosdep2.installers.os.geteuid', return_value=0):
+                test([])
+        else:
             test([])
     except AssertionError:
         traceback.print_exc()


### PR DESCRIPTION
The code itself works on platforms which don't have `os.geteuid`, so the tests should too.