### PR TITLE
Prevent git from adding CR to certain test artifacts

### DIFF
--- a/test/source/.gitattributes
+++ b/test/source/.gitattributes
@@ -1,0 +1,1 @@
+*.rdmanifest text eol=lf


### PR DESCRIPTION
The checksum of these files needs to remain unchanged, and autocrlf conversion would break some of the tests.