### PR TITLE
Add Windows-specific ENOENT error message to test

### DIFF
--- a/test/test_rosdep_installers.py
+++ b/test/test_rosdep_installers.py
@@ -613,7 +613,10 @@ def test_RosdepInstaller_install_resolved(mock_geteuid):
         try:
             installer.install_resolved(APT_INSTALLER, ['rosdep-fake1', 'rosdep-fake2'], simulate=True, verbose=True)
         except OSError as e:
-            if str(e).count('[Errno 2] No such file or directory') == 0:
+            if not any(msg in str(e) for msg in (
+                '[Errno 2] No such file or directory',
+                '[WinError 2] The system cannot find the file specified',
+            )):
                 raise
             return True
     stdout_lines = [x.strip() for x in stdout.getvalue().split('\n') if x.strip()]


### PR DESCRIPTION
There is probably a better way to do this, but my goal is just to unblock the test on Windows for now.