### PR TITLE
Add No-Python2 to stdeb.cfg

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -6,6 +6,7 @@ Depends3: python3-rosdep-modules (>= 0.24.0)
 Conflicts3: python-rosdep, python-rosdep2, python3-rosdep2
 Copyright-File: LICENSE
 Suite3: focal jammy noble bookworm trixie
+No-Python2:
 X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -15,5 +16,6 @@ Conflicts3: python3-rosdep (<< 0.18.0), python3-rosdep2
 Replaces3: python3-rosdep (<< 0.18.0)
 Copyright-File: LICENSE
 Suite3: focal jammy noble bookworm trixie
+No-Python2:
 X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
We no longer want to publish a Python 2 subpackage.