### PR TITLE
Remove more Python 2 artifacts

### DIFF
--- a/src/rosdep2/__init__.py
+++ b/src/rosdep2/__init__.py
@@ -31,8 +31,6 @@
 rosdep library and command-line tool
 """
 
-from __future__ import print_function
-
 from ._version import __version__
 
 import sys

--- a/src/rosdep2/catkin_packages.py
+++ b/src/rosdep2/catkin_packages.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 

--- a/src/rosdep2/catkin_support.py
+++ b/src/rosdep2/catkin_support.py
@@ -15,8 +15,6 @@ Workflow::
 
 """
 
-from __future__ import print_function
-
 import os
 
 from subprocess import Popen, PIPE, CalledProcessError

--- a/src/rosdep2/core.py
+++ b/src/rosdep2/core.py
@@ -25,8 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import os
 import sys
 import traceback

--- a/src/rosdep2/install.py
+++ b/src/rosdep2/install.py
@@ -29,8 +29,6 @@
 Script for installing rdmanifest-described resources
 """
 
-from __future__ import print_function
-
 import os
 import sys
 from optparse import OptionParser

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -27,8 +27,6 @@
 
 # Author Tully Foote/tfoote@willowgarage.com, Ken Conley/kwc@willowgarage.com
 
-from __future__ import print_function
-
 import os
 import subprocess
 import traceback

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -27,8 +27,6 @@
 
 # Author Tully Foote/tfoote@willowgarage.com, Ken Conley/kwc@willowgarage.com
 
-from __future__ import print_function
-
 import sys
 import yaml
 

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -31,8 +31,6 @@
 Command-line interface to rosdep library
 """
 
-from __future__ import print_function
-
 import errno
 import os
 import sys

--- a/src/rosdep2/meta.py
+++ b/src/rosdep2/meta.py
@@ -32,13 +32,6 @@ try:
 except ImportError:
     import pickle
 
-try:
-    FileNotFoundError
-except NameError:
-    # Python 2 compatibility
-    # https://stackoverflow.com/questions/21367320/
-    FileNotFoundError = IOError
-
 import rospkg
 
 from ._version import __version__

--- a/src/rosdep2/platforms/arch.py
+++ b/src/rosdep2/platforms/arch.py
@@ -27,7 +27,6 @@
 
 # Author Tully Foote/tfoote@willowgarage.com
 
-from __future__ import print_function
 import subprocess
 import sys
 

--- a/src/rosdep2/platforms/cygwin.py
+++ b/src/rosdep2/platforms/cygwin.py
@@ -27,8 +27,6 @@
 
 # Tingfan Wu tingfan@gmail.com
 
-from __future__ import print_function
-
 from rospkg.os_detect import OS_CYGWIN
 
 from .source import SOURCE_INSTALLER

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -27,7 +27,6 @@
 
 # Author Tully Foote, Ken Conley
 
-from __future__ import print_function
 import subprocess
 import sys
 

--- a/src/rosdep2/platforms/gem.py
+++ b/src/rosdep2/platforms/gem.py
@@ -28,8 +28,6 @@
 
 # Author Ruben Smits/ruben.smits@intermodalics.eu
 
-from __future__ import print_function
-
 import subprocess
 
 from ..core import InstallFailed

--- a/src/rosdep2/platforms/npm.py
+++ b/src/rosdep2/platforms/npm.py
@@ -26,8 +26,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import os
 import subprocess
 

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -27,8 +27,6 @@
 
 # Author Tully Foote/tfoote@willowgarage.com
 
-from __future__ import print_function
-
 import os
 import subprocess
 import sys

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -27,7 +27,6 @@
 
 # Author Tully Foote/tfoote@willowgarage.com
 
-from __future__ import print_function
 import subprocess
 import sys
 

--- a/src/rosdep2/platforms/source.py
+++ b/src/rosdep2/platforms/source.py
@@ -27,8 +27,6 @@
 
 # Author Tully Foote/tfoote@willowgarage.com
 
-from __future__ import print_function
-
 import os
 try:
     from urllib.request import urlretrieve

--- a/src/rosdep2/rospack.py
+++ b/src/rosdep2/rospack.py
@@ -32,8 +32,6 @@ API provided for rospack to determine if a dependency
 is a ROSpackage or a system dependency
 """
 
-from __future__ import print_function
-
 import subprocess
 
 from .main import _get_default_RosdepLookup

--- a/src/rosdep2/rospkg_loader.py
+++ b/src/rosdep2/rospkg_loader.py
@@ -32,8 +32,6 @@ Library for loading rosdep files from the ROS package/stack
 filesystem.
 """
 
-from __future__ import print_function
-
 import os
 
 import catkin_pkg.package

--- a/src/rosdep2/shell_utils.py
+++ b/src/rosdep2/shell_utils.py
@@ -27,8 +27,6 @@
 
 # Author Tully Foote/tfoote@willowgarage.com
 
-from __future__ import print_function
-
 import os
 import sys
 import stat

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -27,8 +27,6 @@
 
 # Author Ken Conley/kwc@willowgarage.com
 
-from __future__ import print_function
-
 import os
 import sys
 import yaml

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 import subprocess
 import sys
@@ -28,9 +26,9 @@ def test_flake8():
     # See: https://flake8.pycqa.org/en/latest/user/python-api.html
     # Calling through subprocess is the most stable way to run it.
 
-    # We still need to support Python 2.7, so we can't use run()
-    ret_code = subprocess.call(
+    result = subprocess.run(
         [sys.executable, "-m", "flake8"],
         cwd=os.path.dirname(os.path.dirname(__file__)),
+        check=False,
     )
-    assert 0 == ret_code, "flake8 found violations"
+    assert 0 == result.returncode, "flake8 found violations"

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -25,29 +25,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import os
 import sys
-
-try:
-    from tempfile import TemporaryDirectory
-except ImportError:
-    import tempfile
-    import shutil
-
-    class TemporaryDirectory(object):
-        """Python 2 compatible class."""
-
-        def __init__(self):
-            self.name = None
-
-        def __enter__(self):
-            self.name = tempfile.mkdtemp()
-            return self.name
-
-        def __exit__(self, t, v, tb):
-            shutil.rmtree(self.name)
+from tempfile import TemporaryDirectory
 
 from rosdep2.meta import MetaDatabase
 

--- a/test/test_rosdep.py
+++ b/test/test_rosdep.py
@@ -25,8 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import os
 import sys
 

--- a/test/test_rosdep_installers.py
+++ b/test/test_rosdep_installers.py
@@ -25,8 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 from contextlib import contextmanager
 from unittest import SkipTest
 from unittest.mock import Mock, patch

--- a/test/test_rosdep_lookup.py
+++ b/test/test_rosdep_lookup.py
@@ -25,8 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import os
 import yaml
 


### PR DESCRIPTION
We no longer support Python 2 in rosdep so there's no reason to carry these snippets anymore.