### PR TITLE
Updates to run and pass flake8-builtins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ kwargs = {
     'extras_require': {
         'test': [
             'flake8 < 6',
+            'flake8-builtins',
             'flake8-comprehensions',
             'pytest',
         ],

--- a/src/rosdep2/meta.py
+++ b/src/rosdep2/meta.py
@@ -37,7 +37,7 @@ try:
 except NameError:
     # Python 2 compatibility
     # https://stackoverflow.com/questions/21367320/
-    FileNotFoundError = IOError
+    FileNotFoundError = IOError  # noqa: A001
 
 import rospkg
 
@@ -95,7 +95,7 @@ class MetaDatabase:
         self._cache_dir = cache_dir
         self._loaded = {}
 
-    def set(self, category, metadata):
+    def set(self, category, metadata):  # noqa: A003
         """Add or overwrite metadata in the cache."""
         wrapper = CacheWrapper(category, metadata)
         # print(category, metadata)

--- a/src/rosdep2/sources_list.py
+++ b/src/rosdep2/sources_list.py
@@ -231,8 +231,8 @@ class CachedDataSource(object):
     def __repr__(self):
         return repr((self.type, self.url, self.tags, self.rosdep_data, self.origin))
 
-    @property
-    def type(self):
+    @property  # noqa: A003
+    def type(self):  # noqa: A003
         """
         :returns: data source type
         """


### PR DESCRIPTION
There are flake8-builtins violations which appear as part of rosdep's public API. We'll supporess those to avoid breaking API, but still add the linter plugin so we don't regress more.