### PR TITLE
Add --break-system-packages to pip install on python 3.11+

### DIFF
--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -148,7 +148,10 @@ class PipInstaller(PackageManagerInstaller):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)
         if not packages:
             return []
-        cmd = pip_cmd + ['install', '-U']
+        if sys.version_info() >= (3, 11):
+            cmd = pip_cmd + ['install', '-U', '--break-system-packages']
+        else:
+            cmd = pip_cmd + ['install', '-U']
         if quiet:
             cmd.append('-q')
         if reinstall:


### PR DESCRIPTION
Currently on python 3.11+ install a pip package crashes rosdep with the following error

```
  executing command [pip3 install -U -q pytest-qt]
  WARNING: Skipping /usr/lib/python3.12/dist-packages/argcomplete-3.1.4.dist-info due to invalid metadata entry 'name'
  WARNING: Skipping /usr/lib/python3.12/dist-packages/argcomplete-3.1.4.dist-info due to invalid metadata entry 'name'
  error: externally-managed-environment
  
  × This environment is externally managed
  ╰─> To install Python packages system-wide, try apt install
      python3-xyz, where xyz is the package you are trying to
      install.
      
      If you wish to install a non-Debian-packaged Python package,
      create a virtual environment using python3 -m venv path/to/venv.
      Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
      sure you have python3-full installed.
      
      If you wish to install a non-Debian packaged Python application,
      it may be easiest to use pipx install xyz, which will manage a
      virtual environment for you. Make sure you have pipx installed.
      
      See /usr/share/doc/python3.12/README.venv for more information.
  
  note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
  hint: See PEP 668 for the detailed specification.
  ERROR: the following rosdeps failed to install
    pip: command [pip3 install -U -q pytest-qt] failed
```


In the future https://github.com/ros2/ros2/pull/1524 could support virtual environments as well as updating rosdep to support them after that issue gets resolved. However in the interim I added the `--break-system-packages` to python3.11+.
    
Closes #978