### PR TITLE
Check for pip configuration when an externally managed environment is detected.

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -11,3 +11,4 @@ Contents
    sources_list
    developers_guide
    rosdep2_api
+   pip_and_pep_668

--- a/doc/pip_and_pep_668.rst
+++ b/doc/pip_and_pep_668.rst
@@ -3,7 +3,7 @@ Pip installation after PEP 668
 
 `PEP-668`_ introduced `externally managed environments <externally-managed-environments>`_ to Python packaging.
 
-Rosdep is designed to use pip as an alternative system package manager, rosdep installation of pip packages requires installing packages globally as root.
+``rosdep`` is designed to use pip as an alternative system package manager, rosdep installation of pip packages requires installing packages globally as root.
 Starting with Python 3.11, `PEP-668`_ compliance requires you to allow pip to install alongside externally managed packages using the ``break-system-packages`` option.
 
 There are multiple ways to configure pip so that rosdep will succeed.

--- a/doc/pip_and_pep_668.rst
+++ b/doc/pip_and_pep_668.rst
@@ -27,7 +27,7 @@ If your system's sudo configuration prohibits the passing of environment variabl
 Configure using pip.conf
 ------------------------
 
-`Pip configuration files <pip-configuration>`_ can be used to set the desired behavior 
+`Pip configuration files <pip-configuration>`_ can be used to set the desired behavior.
 Pip checks for global configuration files in ``XDG_CONFIG_DIRS``, as well as ``/etc/pip.conf``
 For details on ``XDG_CONFIG_DIRS`` refer to the `XDG base directories specification <xdg-base-dirs>`_.
 If you're unsure which configuration file is in use by your system, ``/etc/pip.conf`` seems like the most generic.

--- a/doc/pip_and_pep_668.rst
+++ b/doc/pip_and_pep_668.rst
@@ -28,13 +28,15 @@ Configure using pip.conf
 `Pip configuration files <pip-configuration>`_ can be used to set the desired behavior 
 Pip checks for global configuration files in ``XDG_CONFIG_DIRS``, as well as ``/etc/pip.conf``
 For details on ``XDG_CONFIG_DIRS`` refer to the `XDG base directories specification <xdg-base-dirs>`_.
-
-Creating a pip.conf in your user account's ``XDG_CONFIG_HOME`` (e.g. ``~/.config/pip/pip.conf``) does not appear to be sufficent when installing packages globally.
+If you're unsure which configuration file is in use by your system, ``/etc/pip.conf`` seems like the most generic.
 
 .. code-block:: ini
 
    [install]
    break-system-packages = true
+
+
+.. warning:: Creating a pip.conf in your user account's ``XDG_CONFIG_HOME`` (e.g. ``~/.config/pip/pip.conf``) does not appear to be sufficent when installing packages globally.
 
 
 Configuring for CI setup

--- a/doc/pip_and_pep_668.rst
+++ b/doc/pip_and_pep_668.rst
@@ -19,8 +19,10 @@ The value of the environment variable can be any of ``1``, ``yes``, or ``true``.
 The string values are not case sensitive.
 
 rosdep is designed to use ``sudo`` in order to gain root privileges for installation when not run as root.
-If your system's sudo configuration prohibits the passing of environment variables
+If your system's sudo configuration prohibits the passing of environment variables use the :ref:`pip.conf <configure-using-pip.conf>` method below.
 
+
+.. _configure-using-pip.conf:
 
 Configure using pip.conf
 ------------------------

--- a/doc/pip_and_pep_668.rst
+++ b/doc/pip_and_pep_668.rst
@@ -1,0 +1,67 @@
+Pip installation after PEP 668
+==============================
+
+`PEP-668`_ introduced `externally managed environments <externally-managed-environments>`_ to Python packaging.
+
+Rosdep is designed to use pip as an alternative system package manager, rosdep installation of pip packages requires installing packages globally as root.
+Starting with Python 3.11, `PEP-668`_ compliance requires you to allow pip to install alongside externally managed packages using the ``break-system-packages`` option.
+
+There are multiple ways to configure pip so that rosdep will succeed.
+
+
+Configure using environment variable
+------------------------------------
+
+This is the way that we recommend configuring pip for rosdep usage.
+We recommend configuring pip using the system environment.
+Setting environment variables in your login profile, ``PIP_BREAK_SYSTEM_PACKAGES`` in your environment.
+The value of the environment variable can be any of ``1``, ``yes``, or ``true``.
+The string values are not case sensitive.
+
+
+Configure using pip.conf
+------------------------
+
+`Pip configuration files <pip-configuration>`_ can be used to set the desired behavior 
+Pip checks for global configuration files in ``XDG_CONFIG_DIRS``, as well as ``/etc/pip.conf``
+For details on ``XDG_CONFIG_DIRS`` refer to the `XDG base directories specification <xdg-base-dirs>`_.
+
+Creating a pip.conf in your user account's ``XDG_CONFIG_HOME`` (e.g. ``~/.config/pip/pip.conf``) does not appear to be sufficent when installing packages globally.
+
+.. code-block:: ini
+
+   [install]
+   break-system-packages = true
+
+
+Configuring for CI setup
+------------------------
+
+Either environment variables or configuration files can be used with your CI system.
+Which one you choose will depend on how your CI environment is configured.
+Perhaps the most straightforward will be to set the environent variable in the shell or script execution context before invoking rosdep.
+
+.. code-block:: bash
+
+   sudo rosdep init
+   rosdep update
+   PIP_BREAK_SYSTEM_PACKAGES=1 rosdep install -r rolling --from-paths src/
+
+If rosdep is invoked by internal processes in your CI and you need to set the configuration without having direct control over how ``rosdep install`` is run, setting the environment variable globally would also work.
+
+.. code-block:: bash
+
+   export PIP_BREAK_SYSTEM_PACKAGES=1
+   ./path/to/ci-script.sh
+
+
+If you cannot set environment variables but you can create configuration files, you can set ``/etc/pip.conf`` with the necessary configuration.
+
+.. code-block:: bash
+
+   printf "[install]\nbreak-system-packages = true\n" | sudo tee -a /etc/pip.conf
+
+.. _PEP-668: https://peps.python.org/pep-0668/
+.. _pip-configuration: https://pip.pypa.io/en/stable/topics/configuration/
+.. _externally-managed-environments: https://packaging.python.org/en/latest/specifications/externally-managed-environments/
+.. _xdg-base-dirs: https://specifications.freedesktop.org/basedir-spec/latest/

--- a/doc/pip_and_pep_668.rst
+++ b/doc/pip_and_pep_668.rst
@@ -28,7 +28,7 @@ Configure using pip.conf
 ------------------------
 
 `Pip configuration files <pip-configuration>`_ can be used to set the desired behavior.
-Pip checks for global configuration files in ``XDG_CONFIG_DIRS``, as well as ``/etc/pip.conf``
+Pip checks for global configuration files in ``XDG_CONFIG_DIRS``, as well as ``/etc/pip.conf``.
 For details on ``XDG_CONFIG_DIRS`` refer to the `XDG base directories specification <xdg-base-dirs>`_.
 If you're unsure which configuration file is in use by your system, ``/etc/pip.conf`` seems like the most generic.
 

--- a/doc/pip_and_pep_668.rst
+++ b/doc/pip_and_pep_668.rst
@@ -3,7 +3,7 @@ Pip installation after PEP 668
 
 `PEP-668`_ introduced `externally managed environments <externally-managed-environments>`_ to Python packaging.
 
-``rosdep`` is designed to use pip as an alternative system package manager, rosdep installation of pip packages requires installing packages globally as root.
+rosdep is designed to use pip as an alternative system package manager, rosdep installation of pip packages requires installing packages globally as root.
 Starting with Python 3.11, `PEP-668`_ compliance requires you to allow pip to install alongside externally managed packages using the ``break-system-packages`` option.
 
 There are multiple ways to configure pip so that rosdep will succeed.
@@ -18,7 +18,7 @@ Setting environment variables in your login profile, ``PIP_BREAK_SYSTEM_PACKAGES
 The value of the environment variable can be any of ``1``, ``yes``, or ``true``.
 The string values are not case sensitive.
 
-``rosdep`` is designed to use ``sudo`` in order to gain root privileges for installation when not run as root.
+rosdep is designed to use ``sudo`` in order to gain root privileges for installation when not run as root.
 If your system's sudo configuration prohibits the passing of environment variables
 
 
@@ -44,7 +44,7 @@ Configuring for CI setup
 
 Either environment variables or configuration files can be used with your CI system.
 Which one you choose will depend on how your CI environment is configured.
-Perhaps the most straightforward will be to set the environent variable in the shell or script execution context before invoking rosdep.
+Perhaps the most straightforward will be to set the environent variable in the shell or script execution context before invoking ``rosdep``.
 
 .. code-block:: bash
 
@@ -52,7 +52,7 @@ Perhaps the most straightforward will be to set the environent variable in the s
    rosdep update
    PIP_BREAK_SYSTEM_PACKAGES=1 rosdep install -r rolling --from-paths src/
 
-If rosdep is invoked by internal processes in your CI and you need to set the configuration without having direct control over how ``rosdep install`` is run, setting the environment variable globally would also work.
+If ``rosdep`` is invoked by internal processes in your CI and you need to set the configuration without having direct control over how ``rosdep install`` is run, setting the environment variable globally would also work.
 
 .. code-block:: bash
 

--- a/doc/pip_and_pep_668.rst
+++ b/doc/pip_and_pep_668.rst
@@ -18,6 +18,9 @@ Setting environment variables in your login profile, ``PIP_BREAK_SYSTEM_PACKAGES
 The value of the environment variable can be any of ``1``, ``yes``, or ``true``.
 The string values are not case sensitive.
 
+``rosdep`` is designed to use ``sudo`` in order to gain root privileges for installation when not run as root.
+If your system's sudo configuration prohibits the passing of environment variables
+
 
 Configure using pip.conf
 ------------------------

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -95,9 +95,10 @@ def externally_managed_installable():
     """
     if sys.version_info < (3, 11):
         return True
-        if 'PIP_BREAK_SYSTEM_PACKAGES' in os.environ and os.environ[
-            'PIP_BREAK_SYSTEM_PACKAGES'
-        ].lower() in ('yes', '1', 'true'):
+        if (
+                'PIP_BREAK_SYSTEM_PACKAGES' in os.environ and
+                os.environ['PIP_BREAK_SYSTEM_PACKAGES'].lower() in ('yes', '1', 'true')
+        ):
             return True
         # Check the same configuration directories as pip does per
         # https://pip.pypa.io/en/stable/topics/configuration/

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -92,14 +92,14 @@ def externally_managed_installable():
     variable.
     """
     if sys.version_info >= (3, 11):
-        if "PIP_BREAK_SYSTEM_PACKAGES" in os.environ and os.environ[
-            "PIP_BREAK_SYSTEM_PACKAGES"
-        ].lower() in ("yes", "1", "true"):
+        if 'PIP_BREAK_SYSTEM_PACKAGES' in os.environ and os.environ[
+            'PIP_BREAK_SYSTEM_PACKAGES'
+        ].lower() in ('yes', '1', 'true'):
             return True
         if 'XDG_CONFIG_DIRS' in os.environ:
             global_config = ConfigParser()
-            for dir in os.environ['XDG_CONFIG_DIRS'].split(":"):
-                global_config_file = Path(dir) / "pip" / "pip.conf"
+            for xdg_dir in os.environ['XDG_CONFIG_DIRS'].split(':'):
+                global_config_file = Path(xdg_dir) / 'pip' / 'pip.conf'
                 global_config.read(global_config_file)
                 if global_config['install']['break-system-packages']:
                     return True

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -98,19 +98,25 @@ def externally_managed_installable():
             'PIP_BREAK_SYSTEM_PACKAGES'
         ].lower() in ('yes', '1', 'true'):
             return True
+        # Check the same configuration directories as pip does per
+        # https://pip.pypa.io/en/stable/topics/configuration/
+        pip_config = ConfigParser()
         if 'XDG_CONFIG_DIRS' in os.environ:
-            global_config = ConfigParser()
             for xdg_dir in os.environ['XDG_CONFIG_DIRS'].split(':'):
-                global_config_file = Path(xdg_dir) / 'pip' / 'pip.conf'
-                global_config.read(global_config_file)
-                if global_config['install']['break-system-packages']:
+                pip_config_file = Path(xdg_dir) / 'pip' / 'pip.conf'
+                pip_config.read(pip_config_file)
+                if pip_config['install']['break-system-packages']:
                     return True
-            fallback_config = Path('/etc/pip.conf')
-            global_config.read(fallback_config)
-            if global_config['install']['break-system-packages']:
-                return True
+
+        fallback_config = Path('/etc/pip.conf')
+        pip_config.read(fallback_config)
+        if pip_config['install']['break-system-packages']:
+            return True
+        # On Python 3.11 and later, when no explicit configuration is present,
+        # global pip installation will not work.
         return False
-    return True
+    else:
+        return True
 
 
 def is_cmd_available(cmd):

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -87,7 +87,7 @@ def get_pip_command():
 def externally_managed_installable():
     """
     PEP 668 enacted in Python 3.11 blocks pip from working in "externally
-    managed" envrionments such operating systems with included package
+    managed" environments such as operating systems with included package
     managers. If we're on Python 3.11 or greater, we need to check that pip
     is configured to allow installing system-wide packages with the
     flagrantly named "break system packages" config option or environment

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -91,7 +91,7 @@ def externally_managed_installable():
     flagrantly named "break system packages" config option or environment
     variable.
     """
-    if sys.version_info[0] == 3 and sys.version_info[1] >= 11:
+    if sys.version_info >= (3, 11):
         if "PIP_BREAK_SYSTEM_PACKAGES" in os.environ and os.environ[
             "PIP_BREAK_SYSTEM_PACKAGES"
         ].lower() in ("yes", "1", "true"):

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -47,7 +47,7 @@ from ..shell_utils import read_stdout
 PIP_INSTALLER = 'pip'
 
 EXTERNALLY_MANAGED_EXPLAINER = """
-rosdep installation of pip packages requires installing packages packages globally as root
+rosdep installation of pip packages requires installing packages globally as root.
 When using Python >= 3.11, PEP 668 compliance requires you to allow pip to install alongside
 externally managed packages using the 'break-system-packages' option.
 The recommeded way to set this option when using rosdep is to set the environment variable

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -172,6 +172,10 @@ class PipInstaller(PackageManagerInstaller):
     def __init__(self):
         super(PipInstaller, self).__init__(pip_detect, supports_depends=True)
 
+        # Pass necessary environment for pip functionality via sudo
+        if self.as_root and self.sudo_command != '':
+            self.sudo_command += ' --preserve-env=PIP_BREAK_SYSTEM_PACKAGES'
+
     def get_version_strings(self):
         pip_version = importlib_metadata.version('pip')
         # keeping the name "setuptools" for backward compatibility

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -93,7 +93,8 @@ def externally_managed_installable():
     flagrantly named "break system packages" config option or environment
     variable.
     """
-    if sys.version_info >= (3, 11):
+    if sys.version_info < (3, 11):
+        return True
         if 'PIP_BREAK_SYSTEM_PACKAGES' in os.environ and os.environ[
             'PIP_BREAK_SYSTEM_PACKAGES'
         ].lower() in ('yes', '1', 'true'):

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -111,12 +111,12 @@ def externally_managed_installable():
         for xdg_dir in os.environ['XDG_CONFIG_DIRS'].split(':'):
             pip_config_file = Path(xdg_dir) / 'pip' / 'pip.conf'
             pip_config.read(pip_config_file)
-            if pip_config['install']['break-system-packages']:
+            if pip_config.getboolean('install', 'break-system-packages', fallback=False):
                 return True
 
     fallback_config = Path('/etc/pip.conf')
     pip_config.read(fallback_config)
-    if pip_config['install']['break-system-packages']:
+    if pip_config.getboolean('install', 'break-system-packages', fallback=False):
         return True
     # On Python 3.11 and later, when no explicit configuration is present,
     # global pip installation will not work.

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -93,32 +93,34 @@ def externally_managed_installable():
     flagrantly named "break system packages" config option or environment
     variable.
     """
+
+    # This doesn't affect Python versions before 3.11
     if sys.version_info < (3, 11):
         return True
-        if (
-                'PIP_BREAK_SYSTEM_PACKAGES' in os.environ and
-                os.environ['PIP_BREAK_SYSTEM_PACKAGES'].lower() in ('yes', '1', 'true')
-        ):
-            return True
-        # Check the same configuration directories as pip does per
-        # https://pip.pypa.io/en/stable/topics/configuration/
-        pip_config = ConfigParser()
-        if 'XDG_CONFIG_DIRS' in os.environ:
-            for xdg_dir in os.environ['XDG_CONFIG_DIRS'].split(':'):
-                pip_config_file = Path(xdg_dir) / 'pip' / 'pip.conf'
-                pip_config.read(pip_config_file)
-                if pip_config['install']['break-system-packages']:
-                    return True
 
-        fallback_config = Path('/etc/pip.conf')
-        pip_config.read(fallback_config)
-        if pip_config['install']['break-system-packages']:
-            return True
-        # On Python 3.11 and later, when no explicit configuration is present,
-        # global pip installation will not work.
-        return False
-    else:
+    if (
+            'PIP_BREAK_SYSTEM_PACKAGES' in os.environ and
+            os.environ['PIP_BREAK_SYSTEM_PACKAGES'].lower() in ('yes', '1', 'true')
+    ):
         return True
+
+    # Check the same configuration directories as pip does per
+    # https://pip.pypa.io/en/stable/topics/configuration/
+    pip_config = ConfigParser()
+    if 'XDG_CONFIG_DIRS' in os.environ:
+        for xdg_dir in os.environ['XDG_CONFIG_DIRS'].split(':'):
+            pip_config_file = Path(xdg_dir) / 'pip' / 'pip.conf'
+            pip_config.read(pip_config_file)
+            if pip_config['install']['break-system-packages']:
+                return True
+
+    fallback_config = Path('/etc/pip.conf')
+    pip_config.read(fallback_config)
+    if pip_config['install']['break-system-packages']:
+        return True
+    # On Python 3.11 and later, when no explicit configuration is present,
+    # global pip installation will not work.
+    return False
 
 
 def is_cmd_available(cmd):

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -94,7 +94,7 @@ def externally_managed_installable():
     if sys.version_info[0] == 3 and sys.version_info[1] >= 11:
         if "PIP_BREAK_SYSTEM_PACKAGES" in os.environ and os.environ[
             "PIP_BREAK_SYSTEM_PACKAGES"
-        ].lower() in ["yes", "1", "true"]:
+        ].lower() in ("yes", "1", "true"):
             return True
         if 'XDG_CONFIG_DIRS' in os.environ:
             global_config = ConfigParser()

--- a/src/rosdep2/platforms/pip.py
+++ b/src/rosdep2/platforms/pip.py
@@ -53,6 +53,8 @@ externally managed packages using the 'break-system-packages' option.
 The recommeded way to set this option when using rosdep is to set the environment variable
 PIP_BREAK_SYSTEM_PACKAGES=1
 in your environment.
+
+For more information refer to http://docs.ros.org/en/independent/api/rosdep/html/pip_and_pep_668.html
 """
 
 

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -67,6 +67,22 @@ def test_PipInstaller_get_depends():
     assert ['foo'] == installer.get_depends(dict(depends=['foo']))
 
 
+@patch('rosdep2.platforms.pip.externally_managed_installable')
+def test_PipInstaller_handles_externally_managed_environment(externally_managed_installable):
+    from rosdep2 import InstallFailed
+    from rosdep2.platforms.pip import EXTERNALLY_MANAGED_EXPLAINER, PipInstaller
+
+    externally_managed_installable.return_value = False
+    installer = PipInstaller()
+    try:
+        installer.get_install_command(['whatever'])
+        assert False, 'should have raised'
+    except InstallFailed as e:
+        assert e.failures == [('pip', EXTERNALLY_MANAGED_EXPLAINER)]
+    externally_managed_installable.return_value = True
+    assert installer.get_install_command(['whatever'], interactive=False)
+
+
 @patch.dict(os.environ, {'PIP_BREAK_SYSTEM_PACKAGES': '1'})
 def test_PipInstaller():
     from rosdep2 import InstallFailed

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -67,6 +67,7 @@ def test_PipInstaller_get_depends():
     assert ['foo'] == installer.get_depends(dict(depends=['foo']))
 
 
+@patch.dict(os.environ, {'PIP_BREAK_SYSTEM_PACKAGES': '1'})
 def test_PipInstaller():
     from rosdep2 import InstallFailed
     from rosdep2.platforms.pip import PipInstaller

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -104,7 +104,7 @@ def test_PipInstaller():
     try:
         if hasattr(os, 'geteuid'):
             with patch('rosdep2.installers.os.geteuid', return_value=1):
-                test(['sudo', '-H'])
+                test(['sudo', '-H', '--preserve-env=PIP_BREAK_SYSTEM_PACKAGES'])
             with patch('rosdep2.installers.os.geteuid', return_value=0):
                 test([])
         else:


### PR DESCRIPTION
rosdep is designed to treat pip like an alternative system-level package manager. Deviating from this approach is not easily achievable without a significant rethinking of how pip packages are managed. In the meantime, we can at least instruct users how to restore the prior functionality.

Rather than inject the environment variable / config on behalf of the user, this change instructs them to make the necessary config changes themself, keeping them informed of the change their making to the system's new default.

I added a documentation page specific to this issue with additional configuration details and recipes for CI.

Seeks to reduce friction related to #978 