### PR TITLE
Ignore egg-info directories wherever they are found.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ target
 build
 deb_dist
 dist
-src/rosdep.egg-info
+rosdep.egg-info/
+rosdep_modules.egg-info/
 nose*
 _build


### PR DESCRIPTION
Ignore both rosdep and rosdep_modules egg info files which in my current build environment show up at the repository root not the src directory.