### PR TITLE
Switch to supported mechanism to skip an unwanted test

### DIFF
--- a/test/test_rosdep_issue30.py
+++ b/test/test_rosdep_issue30.py
@@ -8,8 +8,8 @@ from rosdep2 import main as rdmain
 
 class Issue30TestCase(unittest.TestCase):
 
+    @unittest.skip('Issue is not resolved, see ros-infrastructure/rosdep#37')
     def testIssue30(self):
-        return True
         d = make_temp_dir()
         try:
             cd(d)


### PR DESCRIPTION
The 'git blame' for this return statement states that the test isn't passing right now and references a GitHub ticket. While returning a value from a test might be supported in other test frameworks, it is deprecated in unittest. Rather than returning early from the test so that it is reported as 'passed', we should use a supported mechanism to skip the test so that it is reported as such.

Since the test is implemented using `unittest`, I used that mechanism to skip the test, which also works as expected for pytest.

Resolves:
```test/test_rosdep_issue30.py::Issue30TestCase::testIssue30
  /usr/lib64/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method Issue30TestCase.testIssue30 of <test.test_rosdep_issue30.Issue30TestCase testMethod=testIssue30>>)
    return self.run(*args, **kwds)

```