### PR TITLE
Use rosdep's reported platform for testing OS override

### DIFF
--- a/test/test_rosdep_main.py
+++ b/test/test_rosdep_main.py
@@ -34,11 +34,11 @@ except ImportError:
     from io import StringIO
 
 import rospkg
-import rospkg.os_detect
 
 import unittest
 from unittest.mock import DEFAULT, patch
 
+from rosdep2 import create_default_installer_context
 from rosdep2 import main
 from rosdep2.ament_packages import AMENT_PREFIX_PATH_ENV_VAR
 from rosdep2.main import rosdep_main
@@ -132,8 +132,8 @@ class TestRosdepMain(unittest.TestCase):
             stdout, stderr = b
             assert stdout.getvalue().strip() == 'All system dependencies have been satisfied', stdout.getvalue()
         try:
-            osd = rospkg.os_detect.OsDetect()
-            override = '%s:%s' % (osd.get_name(), osd.get_codename())
+            context = create_default_installer_context()
+            override = '%s:%s' % context.get_os_name_and_version()
             with fakeout() as b:
                 rosdep_main(['check', 'python_dep', '--os', override] + cmd_extras)
                 stdout, stderr = b


### PR DESCRIPTION
This part of the test attempts to invoke a 'check' operation given a specific OS override value. The test currently determines which OS:VER pair to pass by directly calling into `rospkg.os_detect`. While this works as expected for some platforms, it isn't appropriate for platforms which either:
1. Use the OS_VERSION as the key version specifier as opposed to OS_CODENAME.
2. Implicitly override the OS_NAME to alias to another platform.

This change switches to using rosdep's own mechanism to determine which test values to use. There should be no change in behavior to platforms for which neither of the aforementioned cases apply to (e.x. Ubuntu, Debian).

This resolves the test failure on CentOS Stream 10, where the test was trying to pass `centos:coughlan`, for which no rosdep rules exist. It should be aliased to `rhel:10`.