### PR TITLE
Support reinstall in check command

### DIFF
--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -419,13 +419,6 @@ class RosdepInstaller(object):
         self.installer_context = installer_context
         self.lookup = lookup
 
-    def get_all(self, resources, implicit=False, verbose=False):
-        # resolutions have been unique()d
-        if verbose:
-            print('resolving for resources [%s]' % (', '.join(resources)))
-        resolutions, errors = self.lookup.resolve_all(resources, self.installer_context, implicit=implicit)
-        return resolutions, errors
-
     def get_uninstalled(self, resources, implicit=False, verbose=False):
         """
         Get list of system dependencies that have not been installed
@@ -442,7 +435,10 @@ class RosdepInstaller(object):
         :raises: :exc:`RosdepInternalError`
         """
 
-        resolutions, errors = self.get_all(resources, implicit=implicit, verbase=verbose)
+        # resolutions have been unique()d
+        if verbose:
+            print('resolving for resources [%s]' % (', '.join(resources)))
+        resolutions, errors = self.lookup.resolve_all(resources, self.installer_context, implicit=implicit)
 
         # for each installer, figure out what is left to install
         uninstalled = []

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -442,8 +442,6 @@ class RosdepInstaller(object):
 
         # for each installer, figure out what is left to install
         uninstalled = []
-        if resolutions == []:
-            return uninstalled, errors
         for installer_key, resolved in resolutions:  # py3k
             if verbose:
                 print('resolution: %s [%s]' % (installer_key, ', '.join([str(r) for r in resolved])))

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -415,18 +415,19 @@ def normalize_uninstalled_to_list(uninstalled):
 
 class RosdepInstaller(object):
 
-    def __init__(self, installer_context, lookup):
+    def __init__(self, installer_context):
         self.installer_context = installer_context
-        self.lookup = lookup
 
-    def get_uninstalled(self, resources, implicit=False, verbose=False):
+    def get_uninstalled(self, resolutions, verbose=False):
         """
         Get list of system dependencies that have not been installed
         as well as a list of errors from performing the resolution.
         This is a bulk API in order to provide performance
         optimizations in checking install state.
 
-        :param resources: List of resource names (e.g. ROS package names), ``[str]]``
+        :param resolutions: ``[(str, [str])]``.  List of resolution tuples.
+          A resolution tuple's first element is the installer key (e.g.: apt or homebrew)
+          and the second element is a list of installer specific resolution values.
         :param implicit: Install implicit (recursive) dependencies of
             resources.  Default ``False``.
 
@@ -434,11 +435,6 @@ class RosdepInstaller(object):
           Uninstalled is a dictionary with the installer_key as the key.
         :raises: :exc:`RosdepInternalError`
         """
-
-        # resolutions have been unique()d
-        if verbose:
-            print('resolving for resources [%s]' % (', '.join(resources)))
-        resolutions, errors = self.lookup.resolve_all(resources, self.installer_context, implicit=implicit)
 
         # for each installer, figure out what is left to install
         uninstalled = []
@@ -461,7 +457,7 @@ class RosdepInstaller(object):
             if verbose:
                 print('uninstalled: [%s]' % (', '.join([str(p) for p in packages_to_install])))
 
-        return uninstalled, errors
+        return uninstalled
 
     def install(self, uninstalled, interactive=True, simulate=False,
                 continue_on_error=False, reinstall=False, verbose=False, quiet=False):

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -435,12 +435,10 @@ class RosdepInstaller(object):
         :raises: :exc:`RosdepInternalError`
         """
 
-        installer_context = self.installer_context
-
         # resolutions have been unique()d
         if verbose:
             print('resolving for resources [%s]' % (', '.join(resources)))
-        resolutions, errors = self.lookup.resolve_all(resources, installer_context, implicit=implicit)
+        resolutions, errors = self.lookup.resolve_all(resources, self.installer_context, implicit=implicit)
 
         # for each installer, figure out what is left to install
         uninstalled = []
@@ -450,7 +448,7 @@ class RosdepInstaller(object):
             if verbose:
                 print('resolution: %s [%s]' % (installer_key, ', '.join([str(r) for r in resolved])))
             try:
-                installer = installer_context.get_installer(installer_key)
+                installer = self.installer_context.get_installer(installer_key)
             except KeyError as e:  # lookup has to be buggy to cause this
                 raise RosdepInternalError(e)
             try:

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -419,6 +419,13 @@ class RosdepInstaller(object):
         self.installer_context = installer_context
         self.lookup = lookup
 
+    def get_all(self, resources, implicit=False, verbose=False):
+        # resolutions have been unique()d
+        if verbose:
+            print('resolving for resources [%s]' % (', '.join(resources)))
+        resolutions, errors = self.lookup.resolve_all(resources, self.installer_context, implicit=implicit)
+        return resolutions, errors
+
     def get_uninstalled(self, resources, implicit=False, verbose=False):
         """
         Get list of system dependencies that have not been installed
@@ -435,10 +442,7 @@ class RosdepInstaller(object):
         :raises: :exc:`RosdepInternalError`
         """
 
-        # resolutions have been unique()d
-        if verbose:
-            print('resolving for resources [%s]' % (', '.join(resources)))
-        resolutions, errors = self.lookup.resolve_all(resources, self.installer_context, implicit=implicit)
+        resolutions, errors = self.get_all(resources, implicit=implicit, verbase=verbose)
 
         # for each installer, figure out what is left to install
         uninstalled = []

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -711,9 +711,13 @@ def get_keys(lookup, packages, recursive):
 def command_check(lookup, packages, options):
     installer_context = create_default_installer_context(verbose=options.verbose)
     configure_installer_context(installer_context, options)
-    installer = RosdepInstaller(installer_context, lookup)
+    installer = RosdepInstaller(installer_context)
 
-    uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose)
+    # resolutions have been unique()d
+    if options.verbose:
+        print('resolving for resources [%s]' % (', '.join(packages)))
+    resolutions, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
+    uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)
 
     # pretty print the result
     if [v for k, v in uninstalled if v]:
@@ -756,7 +760,7 @@ def command_install(lookup, packages, options):
     # setup installer
     installer_context = create_default_installer_context(verbose=options.verbose)
     configure_installer_context(installer_context, options)
-    installer = RosdepInstaller(installer_context, lookup)
+    installer = RosdepInstaller(installer_context)
 
     if options.reinstall:
         if options.verbose:
@@ -767,7 +771,10 @@ def command_install(lookup, packages, options):
             print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
             return 1
     else:
-        uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose)
+        if options.verbose:
+            print('resolving for resources [%s]' % (', '.join(packages)))
+        resolutions, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
+        uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)
 
     if options.verbose:
         uninstalled_dependencies = normalize_uninstalled_to_list(uninstalled)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -762,18 +762,19 @@ def command_install(lookup, packages, options):
     configure_installer_context(installer_context, options)
     installer = RosdepInstaller(installer_context)
 
-    if options.reinstall:
-        if options.verbose:
+    if options.verbose:
+        if options.reinstall:
             print('reinstall is true, resolving all dependencies')
-        try:
-            uninstalled, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
-        except InvalidData as e:
-            print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
-            return 1
-    else:
-        if options.verbose:
-            print('resolving for resources [%s]' % (', '.join(packages)))
+        print('resolving for resources [%s]' % (', '.join(packages)))
+    try:
         resolutions, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
+    except InvalidData as e:
+        print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
+        return 1
+
+    if options.reinstall:
+        uninstalled = resolutions
+    else:
         uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)
 
     if options.verbose:

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -762,7 +762,7 @@ def command_install(lookup, packages, options):
         if options.verbose:
             print('reinstall is true, resolving all dependencies')
         try:
-            uninstalled, errors = installer.get_all(packages, implicit=options.recursive, verbose=options.verbose)
+            uninstalled, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
         except InvalidData as e:
             print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
             return 1

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -709,13 +709,11 @@ def get_keys(lookup, packages, recursive):
 
 
 def command_check(lookup, packages, options):
-    verbose = options.verbose
-
-    installer_context = create_default_installer_context(verbose=verbose)
+    installer_context = create_default_installer_context(verbose=options.verbose)
     configure_installer_context(installer_context, options)
     installer = RosdepInstaller(installer_context, lookup)
 
-    uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=verbose)
+    uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose)
 
     # pretty print the result
     if [v for k, v in uninstalled if v]:

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -761,13 +761,15 @@ def command_install(lookup, packages, options):
     if options.reinstall:
         if options.verbose:
             print('reinstall is true, resolving all dependencies')
-        try:
-            uninstalled, errors = installer.get_all(packages, implicit=options.recursive, verbose=options.verbose)
-        except InvalidData as e:
-            print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
-            return 1
+        getter = installer.get_all
     else:
-        uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose)
+        getter = installer.get_uninstalled
+
+    try:
+        uninstalled, errors = getter(packages, implicit=options.recursive, verbose=options.verbose)
+    except InvalidData as e:
+        print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
+        return 1
 
     if options.verbose:
         uninstalled_dependencies = normalize_uninstalled_to_list(uninstalled)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -708,7 +708,8 @@ def get_keys(lookup, packages, recursive):
     return list(rosdep_keys)
 
 
-def command_check(lookup, packages, options):
+def _resolve_dependencies(lookup, packages, options):
+    # setup installer
     installer_context = create_default_installer_context(verbose=options.verbose)
     configure_installer_context(installer_context, options)
     installer = RosdepInstaller(installer_context)
@@ -716,13 +717,24 @@ def command_check(lookup, packages, options):
     # resolutions have been unique()d
     if options.verbose:
         print('resolving for resources [%s]' % (', '.join(packages)))
-    resolutions, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
+    try:
+        resolutions, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
+    except InvalidData as e:
+        print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
+        raise
+
     if options.reinstall:
         if options.verbose:
             print('reinstall is true, treating all dependencies as uninstalled')
         uninstalled = resolutions
     else:
         uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)
+
+    return uninstalled, errors, installer
+
+
+def command_check(lookup, packages, options):
+    uninstalled, errors, _ = _resolve_dependencies(lookup, packages, options)
 
     # pretty print the result
     if any(v for k, v in uninstalled):
@@ -757,25 +769,10 @@ def error_to_human_readable(error):
 
 
 def command_install(lookup, packages, options):
-    # setup installer
-    installer_context = create_default_installer_context(verbose=options.verbose)
-    configure_installer_context(installer_context, options)
-    installer = RosdepInstaller(installer_context)
-
-    if options.verbose:
-        print('resolving for resources [%s]' % (', '.join(packages)))
     try:
-        resolutions, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
-    except InvalidData as e:
-        print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
+        uninstalled, errors, installer = _resolve_dependencies(lookup, packages, options)
+    except InvalidData:
         return 1
-
-    if options.reinstall:
-        if options.verbose:
-            print('reinstall is true, treating all dependencies as uninstalled')
-        uninstalled = resolutions
-    else:
-        uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)
 
     if options.verbose:
         uninstalled_dependencies = normalize_uninstalled_to_list(uninstalled)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -761,15 +761,13 @@ def command_install(lookup, packages, options):
     if options.reinstall:
         if options.verbose:
             print('reinstall is true, resolving all dependencies')
-        getter = installer.get_all
+        try:
+            uninstalled, errors = installer.get_all(packages, implicit=options.recursive, verbose=options.verbose)
+        except InvalidData as e:
+            print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
+            return 1
     else:
-        getter = installer.get_uninstalled
-
-    try:
-        uninstalled, errors = getter(packages, implicit=options.recursive, verbose=options.verbose)
-    except InvalidData as e:
-        print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
-        return 1
+        uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose)
 
     if options.verbose:
         uninstalled_dependencies = normalize_uninstalled_to_list(uninstalled)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -746,11 +746,8 @@ def command_check(lookup, packages, options):
     else:
         print('All system dependencies have been satisfied')
     if errors:
-        for package_name, ex in errors.items():
-            if isinstance(ex, rospkg.ResourceNotFound):
-                print('ERROR[%s]: resource not found [%s]' % (package_name, ex.args[0]), file=sys.stderr)
-            else:
-                print('ERROR[%s]: %s' % (package_name, ex), file=sys.stderr)
+        for rosdep_key, error in errors.items():
+            print('%s: %s' % (rosdep_key, error_to_human_readable(error)), file=sys.stderr)
     if uninstalled:
         return 1
     elif errors:

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -762,7 +762,7 @@ def command_install(lookup, packages, options):
         if options.verbose:
             print('reinstall is true, resolving all dependencies')
         try:
-            uninstalled, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
+            uninstalled, errors = installer.get_all(packages, implicit=options.recursive, verbose=options.verbose)
         except InvalidData as e:
             print('ERROR: unable to process all dependencies:\n\t%s' % (e), file=sys.stderr)
             return 1

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -763,8 +763,6 @@ def command_install(lookup, packages, options):
     installer = RosdepInstaller(installer_context)
 
     if options.verbose:
-        if options.reinstall:
-            print('reinstall is true, resolving all dependencies')
         print('resolving for resources [%s]' % (', '.join(packages)))
     try:
         resolutions, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
@@ -773,6 +771,8 @@ def command_install(lookup, packages, options):
         return 1
 
     if options.reinstall:
+        if options.verbose:
+            print('reinstall is true, treating all dependencies as uninstalled')
         uninstalled = resolutions
     else:
         uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -720,7 +720,7 @@ def command_check(lookup, packages, options):
     uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)
 
     # pretty print the result
-    if [v for k, v in uninstalled if v]:
+    if any(v for k, v in uninstalled):
         print('System dependencies have not been satisfied:')
         for installer_key, resolved in uninstalled:
             if resolved:

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -757,11 +757,6 @@ def error_to_human_readable(error):
 
 
 def command_install(lookup, packages, options):
-    # map options
-    install_options = dict(interactive=not options.default_yes, verbose=options.verbose,
-                           reinstall=options.reinstall,
-                           continue_on_error=options.robust, simulate=options.simulate, quiet=options.quiet)
-
     # setup installer
     installer_context = create_default_installer_context(verbose=options.verbose)
     configure_installer_context(installer_context, options)
@@ -803,6 +798,11 @@ def command_install(lookup, packages, options):
             print('Continuing to install resolvable dependencies...', file=sys.stderr)
         else:
             return 1
+
+    # map options
+    install_options = dict(interactive=not options.default_yes, verbose=options.verbose,
+                           reinstall=options.reinstall,
+                           continue_on_error=options.robust, simulate=options.simulate, quiet=options.quiet)
     try:
         installer.install(uninstalled, **install_options)
         if not options.simulate:

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -717,7 +717,12 @@ def command_check(lookup, packages, options):
     if options.verbose:
         print('resolving for resources [%s]' % (', '.join(packages)))
     resolutions, errors = lookup.resolve_all(packages, installer_context, implicit=options.recursive)
-    uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)
+    if options.reinstall:
+        if options.verbose:
+            print('reinstall is true, treating all dependencies as uninstalled')
+        uninstalled = resolutions
+    else:
+        uninstalled = installer.get_uninstalled(resolutions, verbose=options.verbose)
 
     # pretty print the result
     if any(v for k, v in uninstalled):

--- a/test/test_rosdep_installers.py
+++ b/test/test_rosdep_installers.py
@@ -420,10 +420,8 @@ def test_RosdepInstaller_ctor():
     from rosdep2 import create_default_installer_context
     from rosdep2.lookup import RosdepLookup
     from rosdep2.installers import RosdepInstaller
-    lookup = RosdepLookup.create_from_rospkg()
     context = create_default_installer_context()
-    installer = RosdepInstaller(context, lookup)
-    assert lookup == installer.lookup
+    installer = RosdepInstaller(context)
     assert context == installer.installer_context
 
 
@@ -443,7 +441,7 @@ def test_RosdepInstaller_get_uninstalled():
     lookup = RosdepLookup.create_from_rospkg(rospack=rospack, rosstack=rosstack, sources_loader=sources_loader)
     context = create_default_installer_context()
     context.set_os_override('ubuntu', 'lucid')
-    installer = RosdepInstaller(context, lookup)
+    installer = RosdepInstaller(context)
 
     # in this first test, detect_fn detects everything as installed
     fake_apt = get_fake_apt(lambda x: x)
@@ -455,7 +453,8 @@ def test_RosdepInstaller_get_uninstalled():
                  ['roscpp_fake', 'rospack_fake'],
                  ]
         for test in tests:
-            uninstalled, errors = installer.get_uninstalled(test, verbose)
+            resolutions, errors = lookup.resolve_all(test, context)
+            uninstalled = installer.get_uninstalled(resolutions, verbose)
             assert not uninstalled, uninstalled
             assert not errors, errors
 
@@ -464,12 +463,14 @@ def test_RosdepInstaller_get_uninstalled():
     context.set_installer(APT_INSTALLER, fake_apt)
 
     for verbose in [True, False]:
-        uninstalled, errors = installer.get_uninstalled(['empty'], verbose)
+        resolutions, errors = lookup.resolve_all(['empty'], context)
+        uninstalled = installer.get_uninstalled(resolutions, verbose)
         assert not uninstalled, uninstalled
         assert not errors
 
         expected = set(['libltdl-dev', 'libboost1.40-all-dev', 'libtool'])
-        uninstalled, errors = installer.get_uninstalled(['roscpp_fake'], verbose)
+        resolutions, errors = lookup.resolve_all(['roscpp_fake'], context)
+        uninstalled = installer.get_uninstalled(resolutions, verbose)
         keys, values = zip(*uninstalled)
         apt_uninstalled = []
         for k, v in uninstalled:
@@ -480,7 +481,8 @@ def test_RosdepInstaller_get_uninstalled():
         assert not errors
 
         expected = ['libtinyxml-dev']
-        uninstalled, errors = installer.get_uninstalled(['rospack_fake'], verbose)
+        resolutions, errors = lookup.resolve_all(['rospack_fake'], context)
+        uninstalled  = installer.get_uninstalled(resolutions, verbose)
         keys, values = zip(*uninstalled)
         apt_uninstalled = []
         for k, v in uninstalled:
@@ -521,21 +523,24 @@ def test_RosdepInstaller_get_uninstalled_unconfigured():
     lookup = RosdepLookup.create_from_rospkg(rospack=rospack, rosstack=rosstack, sources_loader=sources_loader)
     context = create_default_installer_context()
     context.set_os_override('ubuntu', 'lucid')
-    installer = RosdepInstaller(context, lookup)
+    installer = RosdepInstaller(context)
     # - delete the apt installer
     context.set_installer(APT_INSTALLER, None)
 
     for verbose in [True, False]:
-        uninstalled, errors = installer.get_uninstalled(['empty'], verbose)
+        resolutions, errors = lookup.resolve_all(['empty'], context)
+        uninstalled = installer.get_uninstalled(resolutions, verbose)
         assert not uninstalled, uninstalled
         assert not errors
 
         # make sure there is an error when we lookup something that resolves to an apt depend
-        uninstalled, errors = installer.get_uninstalled(['roscpp_fake'], verbose)
+        resolutions, errors = lookup.resolve_all(['roscpp_fake'], context)
+        uninstalled = installer.get_uninstalled(resolutions, verbose)
         assert not uninstalled, uninstalled
         assert list(errors.keys()) == ['roscpp_fake']
 
-        uninstalled, errors = installer.get_uninstalled(['roscpp_fake', 'stack1_p1'], verbose)
+        resolutions, errors = lookup.resolve_all(['roscpp_fake', 'stack1_p1'], context)
+        uninstalled = installer.get_uninstalled(resolutions, verbose)
         assert not uninstalled, uninstalled
         assert set(errors.keys()) == set(['roscpp_fake', 'stack1_p1'])
         print(errors)
@@ -551,7 +556,8 @@ def test_RosdepInstaller_get_uninstalled_unconfigured():
             raise Exception('deadbeef')
     context.set_installer(APT_INSTALLER, BadInstaller())
     try:
-        installer.get_uninstalled(['roscpp_fake'])
+        resolutions, errors = lookup.resolve_all(['roscpp_fake'], context)
+        installer.get_uninstalled(resolutions)
         assert False, 'should have raised'
     except RosdepInternalError as e:
         assert 'apt' in str(e)
@@ -560,9 +566,10 @@ def test_RosdepInstaller_get_uninstalled_unconfigured():
     lookup = Mock(spec=RosdepLookup)
     lookup.resolve_all.return_value = ([('bad-key', ['stuff'])], [])
 
-    installer = RosdepInstaller(context, lookup)
+    installer = RosdepInstaller(context)
     try:
-        installer.get_uninstalled(['roscpp_fake'])
+        resolutions, errors = lookup.resolve_all(['roscpp_fake'], context)
+        installer.get_uninstalled(resolutions)
         assert False, 'should have raised'
     except RosdepInternalError:
         pass
@@ -598,7 +605,7 @@ def test_RosdepInstaller_install_resolved(mock_geteuid):
     lookup = RosdepLookup.create_from_rospkg(rospack=rospack, rosstack=rosstack, sources_loader=sources_loader)
     context = create_default_installer_context()
     context.set_os_override('ubuntu', 'lucid')
-    installer = RosdepInstaller(context, lookup)
+    installer = RosdepInstaller(context)
 
     with fakeout() as (stdout, stderr):
         installer.install_resolved(APT_INSTALLER, [], simulate=True, verbose=False)


### PR DESCRIPTION
Adds `--reinstall` support also for the `check` command, so we can get a full list of deps.
Useful for things like CI and packaging where you want to spit out all dependencies to do something with them later on.

Additionally adds some consistency in output between commands.