### PR TITLE
Remove unecessary global declarations.

### DIFF
--- a/src/rosdep2/catkin_packages.py
+++ b/src/rosdep2/catkin_packages.py
@@ -19,7 +19,6 @@ def find_catkin_packages_in(path, verbose=False):
     :returns: a list of packages in a given directory
     :raises: OSError if the path doesn't exist
     """
-    global _catkin_packages_cache
     if not os.path.exists(path):
         raise OSError("given path '{0}' does not exist".format(path))
     if verbose:
@@ -51,5 +50,4 @@ def set_workspace_packages(packages):
 
 
 def get_workspace_packages():
-    global _catkin_workspace_packages
     return _catkin_workspace_packages


### PR DESCRIPTION
Because these variables are in the local scope and are not re-assigned
in these functions, the global declaration can be omitted.

Recent versions of flake8 now raise F824[1] on these lines.
I am not sure if they were added defensively or if they were previously
required to access these variables as globals. Tests all pass as-is but
if we prefer to keep the defensive global declaration we can modify
these lines to `noqa: F824`.

[1]: https://flake8.pycqa.org/en/latest/user/error-codes.html
