### PR TITLE
Use modern intersphinx_mapping syntax

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -232,4 +232,4 @@ man_pages = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
Support for the legacy syntax was dropped in Sphinx 8. See sphinx-doc/sphinx#12083.