### PR TITLE
Deduplicate virtual packages

### DIFF
--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -265,16 +265,13 @@ def dpkg_detect(pkgs, exec_fn=None):
 
 
 def _iterate_packages(packages, reinstall):
-    for entry in _read_apt_cache_showpkg(packages):
-        p, is_virtual, providers = entry
+    for p, is_virtual, providers in _read_apt_cache_showpkg(packages):
         if is_virtual:
-            installed = []
             if reinstall:
                 installed = dpkg_detect(providers)
                 if len(installed) > 0:
-                    for i in installed:
-                        yield i
-                    continue  # don't ouput providers
+                    yield from installed
+                    continue
             yield providers
         else:
             yield p

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -213,7 +213,10 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
         except StopIteration:
             pass
 
-        pr = [line.split(' ', 2)[0] for line in lines]
+        # Same packages may appear multiple times with different versions.
+        # Because we are discarding the version, we deduplicate the package names
+        # We use a dict to preserve insertion order
+        pr = list({line.split(' ', 2)[0]: None for line in lines})
         if pr:
             yield p, True, pr
         else:

--- a/test/test_rosdep_debian.py
+++ b/test/test_rosdep_debian.py
@@ -159,7 +159,7 @@ def test_iterate_packages():
 
         with patch('rosdep2.platforms.debian.dpkg_detect') as mock_dpkg_detect:
             assert tuple(_iterate_packages(pkgs, False)) == ('curl', 'wget', '_not_existing',
-                                                             ['libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev', 'libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev'],
+                                                             ['libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev'],
                                                              'ros-kinetic-rc-genicam-api')
 
             # reinstall only the virtual packages already installed
@@ -169,5 +169,5 @@ def test_iterate_packages():
             # reinstall all the virtual packages if none are installed
             mock_dpkg_detect.return_value = []  # these libcurl-dev providers are installed
             assert tuple(_iterate_packages(pkgs, True)) == ('curl', 'wget', '_not_existing',
-                                                            ['libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev', 'libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev'],
+                                                            ['libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev'],
                                                             'ros-kinetic-rc-genicam-api')

--- a/test/test_rosdep_debian.py
+++ b/test/test_rosdep_debian.py
@@ -148,16 +148,13 @@ def test_iterate_packages():
     from rosdep2.platforms.debian import _iterate_packages
 
     with patch('rosdep2.platforms.debian._read_apt_cache_showpkg') as mock_read_apt_cache_showpkg:
-        m = Mock()
         with open(os.path.join(get_test_dir(), 'showpkg-curl-wget-libcurl-dev'), 'r') as f:
-            m.return_value = f.read()
+            m = Mock(return_value=f.read())
+
+        mock_read_apt_cache_showpkg.side_effect = lambda pkgs: _read_apt_cache_showpkg(pkgs, exec_fn=m)
+
         pkgs = ['curl', 'wget', '_not_existing', 'libcurl-dev', 'ros-kinetic-rc-genicam-api']
-
-        def proxy_read_apt_cache_showpkg(packages):
-            return _read_apt_cache_showpkg(packages, exec_fn=m)
-        mock_read_apt_cache_showpkg.side_effect = proxy_read_apt_cache_showpkg
-
-        results = [*proxy_read_apt_cache_showpkg(pkgs)]
+        results = [*mock_read_apt_cache_showpkg(pkgs)]
         assert len(results) == len(pkgs), results
 
         with patch('rosdep2.platforms.debian.dpkg_detect') as mock_dpkg_detect:

--- a/test/test_rosdep_debian.py
+++ b/test/test_rosdep_debian.py
@@ -64,7 +64,6 @@ def test_dpkg_detect():
         val = dpkg_detect(['apt', 'tinyxml-dev', 'python'])
         assert val == ['apt', 'python'], val
         assert mock_read_stdout.call_count == 2
-        print(mock_read_stdout.call_args_list[0])
         assert mock_read_stdout.call_args_list[1] == call(['apt-cache', 'showpkg', 'tinyxml-dev'])
 
     # test version lock code (should be filtered out w/o validation)
@@ -126,7 +125,6 @@ def test_AptInstaller():
         expected = [expected_prefix + ['apt-get', 'install', '-y', 'a'],
                     expected_prefix + ['apt-get', 'install', '-y', 'b']]
         val = installer.get_install_command(['whatever'], interactive=False)
-        print('VAL', val)
         assert val == expected, val
         expected = [expected_prefix + ['apt-get', 'install', 'a'],
                     expected_prefix + ['apt-get', 'install', 'b']]

--- a/test/test_rosdep_debian.py
+++ b/test/test_rosdep_debian.py
@@ -161,8 +161,16 @@ def test_iterate_packages():
         assert len(results) == len(pkgs), results
 
         with patch('rosdep2.platforms.debian.dpkg_detect') as mock_dpkg_detect:
-            mock_dpkg_detect.return_value = ['libcurl4-openssl-dev', 'libcurl4-nss-dev']  # these libcurl-dev providers are installed
-            assert tuple(_iterate_packages(pkgs, True)) == ('curl', 'wget', '_not_existing', 'libcurl4-openssl-dev', 'libcurl4-nss-dev', 'ros-kinetic-rc-genicam-api')
             assert tuple(_iterate_packages(pkgs, False)) == ('curl', 'wget', '_not_existing',
                                                              ['libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev', 'libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev'],
                                                              'ros-kinetic-rc-genicam-api')
+
+            # reinstall only the virtual packages already installed
+            mock_dpkg_detect.return_value = ['libcurl4-openssl-dev', 'libcurl4-nss-dev']  # these libcurl-dev providers are installed
+            assert tuple(_iterate_packages(pkgs, True)) == ('curl', 'wget', '_not_existing', 'libcurl4-openssl-dev', 'libcurl4-nss-dev', 'ros-kinetic-rc-genicam-api')
+
+            # reinstall all the virtual packages if none are installed
+            mock_dpkg_detect.return_value = []  # these libcurl-dev providers are installed
+            assert tuple(_iterate_packages(pkgs, True)) == ('curl', 'wget', '_not_existing',
+                                                            ['libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev', 'libcurl4-openssl-dev', 'libcurl4-nss-dev', 'libcurl4-gnutls-dev'],
+                                                            'ros-kinetic-rc-genicam-api')


### PR DESCRIPTION
adds a test for `_iterate_packages`
fixes virtual package providers being listed more than once