### PR TITLE
Add conda (formerly: RoboStack) platform

### DIFF
--- a/src/rosdep2/__init__.py
+++ b/src/rosdep2/__init__.py
@@ -55,6 +55,7 @@ except ImportError:
 def create_default_installer_context(verbose=False):
     from .platforms import alpine
     from .platforms import arch
+    from .platforms import conda
     from .platforms import cygwin
     from .platforms import debian
     from .platforms import gentoo
@@ -70,7 +71,7 @@ def create_default_installer_context(verbose=False):
     from .platforms import slackware
     from .platforms import source
 
-    platform_mods = [alpine, arch, cygwin, debian, gentoo, nix, openembedded, opensuse, osx, redhat, slackware, freebsd]
+    platform_mods = [alpine, arch, conda, cygwin, debian, gentoo, nix, openembedded, opensuse, osx, redhat, slackware, freebsd]
     installer_mods = [source, pip, gem, npm] + platform_mods
 
     context = InstallerContext()

--- a/src/rosdep2/gbpdistro_support.py
+++ b/src/rosdep2/gbpdistro_support.py
@@ -5,12 +5,14 @@ except ImportError:
     import urllib.parse as urlparse  # py3k
 import os
 
+from rospkg.os_detect import OS_CONDA
 from rospkg.os_detect import OS_DEBIAN
 from rospkg.os_detect import OS_FEDORA
 from rospkg.os_detect import OS_OSX
 from rospkg.os_detect import OS_UBUNTU
 
 from .core import InvalidData, DownloadFailure
+from .platforms.conda import CONDA_INSTALLER
 from .platforms.debian import APT_INSTALLER
 from .platforms.osx import BREW_INSTALLER
 from .platforms.redhat import YUM_INSTALLER
@@ -161,6 +163,14 @@ def get_gbprepo_as_rosdep_data(gbpdistro):
             homebrew_name = '%s/%s/%s' % (tap, release_name, rosdep_key)
             rosdep_data[pkg][OS_OSX] = {
                 BREW_INSTALLER: {'packages': [homebrew_name]}
+            }
+
+            # Do generation for conda entries
+            # conda package naming follows debian convention: ros-{release}-{package}
+            conda_package_name = 'ros-%s-%s' % (release_name, pkg)
+            conda_package_name = conda_package_name.replace('_', '-')
+            rosdep_data[pkg][OS_CONDA] = {
+                CONDA_INSTALLER: {'packages': [conda_package_name]}
             }
 
             # - package name: underscores must be dashes

--- a/src/rosdep2/gbpdistro_support.py
+++ b/src/rosdep2/gbpdistro_support.py
@@ -5,7 +5,6 @@ except ImportError:
     import urllib.parse as urlparse  # py3k
 import os
 
-from rospkg.os_detect import OS_CONDA
 from rospkg.os_detect import OS_DEBIAN
 from rospkg.os_detect import OS_FEDORA
 from rospkg.os_detect import OS_OSX

--- a/src/rosdep2/gbpdistro_support.py
+++ b/src/rosdep2/gbpdistro_support.py
@@ -165,14 +165,6 @@ def get_gbprepo_as_rosdep_data(gbpdistro):
                 BREW_INSTALLER: {'packages': [homebrew_name]}
             }
 
-            # Do generation for conda entries
-            # conda package naming follows debian convention: ros-{release}-{package}
-            conda_package_name = 'ros-%s-%s' % (release_name, pkg)
-            conda_package_name = conda_package_name.replace('_', '-')
-            rosdep_data[pkg][OS_CONDA] = {
-                CONDA_INSTALLER: {'packages': [conda_package_name]}
-            }
-
             # - package name: underscores must be dashes
             package_name = 'ros-%s-%s' % (release_name, pkg)
             package_name = package_name.replace('_', '-')

--- a/src/rosdep2/platforms/conda.py
+++ b/src/rosdep2/platforms/conda.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025, Open Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from rospkg.os_detect import OS_CONDA
+
+from ..installers import PackageManagerInstaller
+
+CONDA_INSTALLER = 'conda'
+
+
+def register_installers(context):
+    context.set_installer(CONDA_INSTALLER, CondaInstaller())
+
+
+def register_platforms(context):
+    context.add_os_installer_key(OS_CONDA, CONDA_INSTALLER)
+    context.set_default_os_installer_key(OS_CONDA, lambda self: CONDA_INSTALLER)
+
+
+def conda_detect(packages):
+    # Return empty list - no packages detected as installed
+    # This is a stub implementation for package mapping only
+    return []
+
+
+class CondaInstaller(PackageManagerInstaller):
+
+    def __init__(self):
+        super(CondaInstaller, self).__init__(conda_detect)
+
+    def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
+        raise NotImplementedError(
+            'Conda installer does not support package installation through rosdep. '
+            'Please manage conda packages manually in your conda environment.'
+        )

--- a/src/rosdep2/platforms/conda.py
+++ b/src/rosdep2/platforms/conda.py
@@ -42,9 +42,11 @@ def register_platforms(context):
 
 
 def conda_detect(packages):
-    # Return empty list - no packages detected as installed
     # This is a stub implementation for package mapping only
-    return []
+    raise NotImplementedError(
+        "Conda installer does not support package detection." \
+        "Please manage conda packages manually in your conda environment."
+    )
 
 
 class CondaInstaller(PackageManagerInstaller):

--- a/src/rosdep2/platforms/conda.py
+++ b/src/rosdep2/platforms/conda.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, Open Robotics
+# Copyright (c) 2025, Open Source Robotics Foundation, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This is a continuation of #810. 

The scope of #810 has been trimmed down after a discussion with @cottsay and @traversaro . This PR only adds the necessary constants and machinery to add conda as a supported rosdep mapping. I based this mostly on the original PR and the nix implementation.

@traversaro, I wasn't sure if you wanted to rename some keys?