### PR TITLE
[Supersede #919] Add openEuler support and fix ordering

### DIFF
--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -34,10 +34,10 @@ from rospkg.os_detect import (
     OS_ALMALINUX,
     OS_CENTOS,
     OS_FEDORA,
+    OS_OPENEULER,
     OS_ORACLE,
     OS_RHEL,
-    OS_ROCKY,
-    OS_OPENEULER
+    OS_ROCKY
 )
 
 from .pip import PIP_INSTALLER
@@ -60,13 +60,22 @@ def register_installers(context):
 
 def register_platforms(context):
     register_fedora(context)
-    register_rhel(context)
     register_openeuler(context)
+    register_rhel(context)
     # Aliases
     register_rhel_clone(context, OS_ALMALINUX)
     register_rhel_clone(context, OS_CENTOS)
     register_rhel_clone(context, OS_ORACLE)
     register_rhel_clone(context, OS_ROCKY)
+
+
+def register_fedora(context):
+    context.add_os_installer_key(OS_FEDORA, PIP_INSTALLER)
+    context.add_os_installer_key(OS_FEDORA, DNF_INSTALLER)
+    context.add_os_installer_key(OS_FEDORA, YUM_INSTALLER)
+    context.add_os_installer_key(OS_FEDORA, SOURCE_INSTALLER)
+    context.set_default_os_installer_key(OS_FEDORA, lambda self: DNF_INSTALLER if self.get_version().isdigit() and int(self.get_version()) > 21 else YUM_INSTALLER)
+    context.set_os_version_type(OS_FEDORA, lambda self: self.get_version() if self.get_version().isdigit() and int(self.get_version()) > 20 else self.get_codename())
 
 
 def register_openeuler(context):
@@ -76,14 +85,6 @@ def register_openeuler(context):
     context.add_os_installer_key(OS_OPENEULER, SOURCE_INSTALLER)
     context.set_default_os_installer_key(OS_OPENEULER, lambda self: DNF_INSTALLER)
     context.set_os_version_type(OS_OPENEULER, lambda self: self.get_version())
-
-def register_fedora(context):
-    context.add_os_installer_key(OS_FEDORA, PIP_INSTALLER)
-    context.add_os_installer_key(OS_FEDORA, DNF_INSTALLER)
-    context.add_os_installer_key(OS_FEDORA, YUM_INSTALLER)
-    context.add_os_installer_key(OS_FEDORA, SOURCE_INSTALLER)
-    context.set_default_os_installer_key(OS_FEDORA, lambda self: DNF_INSTALLER if self.get_version().isdigit() and int(self.get_version()) > 21 else YUM_INSTALLER)
-    context.set_os_version_type(OS_FEDORA, lambda self: self.get_version() if self.get_version().isdigit() and int(self.get_version()) > 20 else self.get_codename())
 
 
 def register_rhel(context):

--- a/src/rosdep2/platforms/redhat.py
+++ b/src/rosdep2/platforms/redhat.py
@@ -36,7 +36,8 @@ from rospkg.os_detect import (
     OS_FEDORA,
     OS_ORACLE,
     OS_RHEL,
-    OS_ROCKY
+    OS_ROCKY,
+    OS_OPENEULER
 )
 
 from .pip import PIP_INSTALLER
@@ -60,13 +61,21 @@ def register_installers(context):
 def register_platforms(context):
     register_fedora(context)
     register_rhel(context)
-
+    register_openeuler(context)
     # Aliases
     register_rhel_clone(context, OS_ALMALINUX)
     register_rhel_clone(context, OS_CENTOS)
     register_rhel_clone(context, OS_ORACLE)
     register_rhel_clone(context, OS_ROCKY)
 
+
+def register_openeuler(context):
+    context.add_os_installer_key(OS_OPENEULER, PIP_INSTALLER)
+    context.add_os_installer_key(OS_OPENEULER, DNF_INSTALLER)
+    context.add_os_installer_key(OS_OPENEULER, YUM_INSTALLER)
+    context.add_os_installer_key(OS_OPENEULER, SOURCE_INSTALLER)
+    context.set_default_os_installer_key(OS_OPENEULER, lambda self: DNF_INSTALLER)
+    context.set_os_version_type(OS_OPENEULER, lambda self: self.get_version())
 
 def register_fedora(context):
     context.add_os_installer_key(OS_FEDORA, PIP_INSTALLER)


### PR DESCRIPTION
## Description
This PR continues the work initiated in #919 to add support for openEuler, as the original author has been unresponsive for some time. 

I have incorporated all changes from the original PR and addressed the specific feedback provided by the reviewers regarding the code structure.

## Changes
- Ported openEuler support from #919.
- **Fixed ordering**: Registered the new OS in alphabetical order and ensured the definition follows the same order for better readability and maintenance, as requested in [this discussion](https://github.com/ros-infrastructure/rosdep/pull/919#discussion_r2633379240).

## Related Issues
- Supersedes #919

---
*Note: Credit for the initial implementation goes to @Z572.*